### PR TITLE
adding num_threads()

### DIFF
--- a/generator/wrapper_gen.py
+++ b/generator/wrapper_gen.py
@@ -134,6 +134,7 @@ cdef extern from "daal.h":
 cdef extern from "daal4py_cpp.h":
     cdef void c_daalinit(int nthreads) except +
     cdef void c_daalfini() except +
+    cdef size_t c_num_threads() except +
     cdef size_t c_num_procs() except +
     cdef size_t c_my_procid() except +
 
@@ -143,6 +144,9 @@ def daalinit(nthreads = -1):
 
 def daalfini():
     c_daalfini()
+
+def num_threads():
+    return c_num_threads()
 
 def num_procs():
     return c_num_procs()

--- a/src/daal4py.cpp
+++ b/src/daal4py.cpp
@@ -463,6 +463,12 @@ void c_daalfini()
 #endif
 }
 
+size_t c_num_threads()
+{
+    return daal::services::Environment::getInstance()->getNumberOfThreads();
+}
+
+
 size_t c_num_procs()
 {
 #ifdef _DIST_

--- a/src/daal4py.h
+++ b/src/daal4py.h
@@ -50,6 +50,7 @@ using daal::services::LibraryVersionInfo;
 extern "C" {
 void c_daalinit(int nthreads=-1);
 void c_daalfini();
+size_t c_num_threads();
 size_t c_num_procs();
 size_t c_my_procid();
 }


### PR DESCRIPTION
@oleksandr-pavlyk implementing #14 

daal4py.num_threads() return number of threads used by DAAL.