### PR TITLE
using correct string2enum hash

### DIFF
--- a/generator/format.py
+++ b/generator/format.py
@@ -95,16 +95,17 @@ def mk_var(name='', typ='', const='', dflt=None, inpt=False, algo=None):
                 ptr        = '*' if '*' in typ or any(typ.endswith(x) for x in ['Ptr', '__iface__']) else ''
                 # get rid of ref/ptr in type
                 realtyp    = typ.replace('&', '').replace('*', '').strip()
-                # string to enum dict for our algo, needed for converting python strings to C++ enums
-                s2e = 's2e_algorithms_{}'.format(algo)
 
                 # we try to identify enum types, which become strings in python
                 if '::' in realtyp and not any(x in realtyp for x in ['Ptr', 'std::']):
+                    # string to enum dict for our algo, needed for converting python strings to C++ enums
+                    s2e = 's2e_algorithms_{}'.format(flat(realtyp.rsplit('::', 1)[0]))
                     typ = 'std::string'
                     ref = '&'
                     todaal_member = '({})string2enum(_{}, {})'.format(realtyp, d4pname, s2e)
                 else:
                     # any other typ
+                    s2e = 's2e_algorithms_{}'.format(algo)
                     typ = realtyp
                     todaal_member = '_{}'.format(d4pname)
                 # normalize types from DAAL

--- a/generator/gen_daal4py.py
+++ b/generator/gen_daal4py.py
@@ -832,7 +832,7 @@ class cython_interface(object):
 
         for ns in algos:
             if ns.startswith('algorithms::') and not ns.startswith('algorithms::neural_networks') and self.namespace_dict[ns].enums:
-                cpp_begin += 'static std::map< std::string, int64_t > s2e_' + ns.replace('::', '_') + ' =\n{\n'
+                cpp_begin += 'static str2i_map_t s2e_' + ns.replace('::', '_') + ' =\n{\n'
                 for e in  self.namespace_dict[ns].enums:
                     for v in self.namespace_dict[ns].enums[e]:
                         vv = ns + '::' + v
@@ -844,7 +844,7 @@ class cython_interface(object):
                 for e in  self.namespace_dict[ns].enums:
                     enm = '::'.join([ns, e])
                     if enm in enum_maps:
-                        cpp_begin += 'static std::map< int64_t, std::string > e2s_' + ns.replace('::', '_') + '_' + enum_maps[enm] +' =\n{\n'
+                        cpp_begin += 'static i2str_map_t e2s_' + ns.replace('::', '_') + '_' + enum_maps[enm] +' =\n{\n'
                         for v in self.namespace_dict[ns].enums[e]:
                             vv = ns + '::' + v
                             cpp_begin += ' '*4 +'{daal::' + vv + ', "' + v + '"},\n'

--- a/src/daal4py.cpp
+++ b/src/daal4py.cpp
@@ -193,7 +193,7 @@ PyObject * make_nda(daal::data_management::NumericTablePtr * ptr)
     throw std::invalid_argument("Got unsupported table type.");
 }
 
-extern PyObject * make_nda(daal::data_management::KeyValueDataCollectionPtr * dict, const std::map< int64_t, std::string > & id2str)
+extern PyObject * make_nda(daal::data_management::KeyValueDataCollectionPtr * dict, const i2str_map_t & id2str)
 {
     PyObject *pydict = PyDict_New();
     for(size_t i=0; i<(*dict)->size(); ++i) {
@@ -318,7 +318,7 @@ daal::data_management::NumericTablePtr * make_nt(PyObject * nda)
 	return new daal::data_management::NumericTablePtr();
 }
 
-extern daal::data_management::KeyValueDataCollectionPtr * make_dnt(PyObject * dict, std::map< std::string, int64_t > & str2id)
+extern daal::data_management::KeyValueDataCollectionPtr * make_dnt(PyObject * dict, str2i_map_t & str2id)
 {
     auto dc = new daal::data_management::KeyValueDataCollectionPtr(new daal::data_management::KeyValueDataCollection);
     if(dict && dict != Py_None) {
@@ -415,15 +415,24 @@ void to_c_array(const daal::data_management::NumericTablePtr * ptr, void ** data
     return;
 }
 
-int64_t string2enum(const std::string& str, std::map< std::string, int64_t > & strmap)
+static int64_t getval_(const std::string& str, const str2i_map_t & strmap)
+{
+        auto i = strmap.find(str);
+        if(i == strmap.end()) throw std::invalid_argument(std::string("Encountered unexpected string-identifier '")
+                                                                      + str
+                                                                      + std::string("'"));
+        return i->second;
+}
+
+int64_t string2enum(const std::string& str, str2i_map_t & strmap)
 {
     int64_t r = 0;
     std::size_t current, previous = 0;
     while((current = str.find('|', previous)) != std::string::npos) {
-        r |= strmap[str.substr(previous, current - previous)];
+        r |= getval_(str.substr(previous, current - previous), strmap);
         previous = current + 1;
     }
-    return (r | strmap[str.substr(previous, current - previous)]);
+    return (r | getval_(str.substr(previous, current - previous), strmap));
 }
 
 

--- a/src/daal4py.h
+++ b/src/daal4py.h
@@ -36,6 +36,7 @@ using daal::services::LibraryVersionInfo;
 #include <vector>
 #include <limits>
 #include <string>
+#include <unordered_map>
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 #include <numpy/arrayobject.h>
 
@@ -58,6 +59,8 @@ size_t c_my_procid();
 typedef daal::services::SharedPtr< std::vector< std::vector< daal::byte > > > BytesArray;
 typedef daal::data_management::interface1::NumericTablePtr NumericTablePtr;
 typedef std::string std_string;
+typedef std::unordered_map<std::string, int64_t> str2i_map_t;
+typedef std::unordered_map<int64_t, std::string> i2str_map_t;
 
 template< typename T >
 bool use_default(const daal::services::SharedPtr<T> * attr)
@@ -195,7 +198,7 @@ void * get_nt_data_ptr(const daal::data_management::NumericTablePtr * ptr)
     return dptr ? reinterpret_cast< void* >(dptr->getArraySharedPtr().get()) : NULL;
 }
 
-extern int64_t string2enum(const std::string& str, std::map< std::string, int64_t > & strmap);
+extern int64_t string2enum(const std::string& str, str2i_map_t & strmap);
 
 static std::string to_std_string(PyObject * o)
 {
@@ -211,9 +214,9 @@ typedef daal::data_management::KeyValueDataCollectionPtr dict_NumericTablePtr;
 
 extern "C" void to_c_array(const daal::data_management::NumericTablePtr * ptr, void ** data, size_t * dims, char dtype = 0);
 extern PyObject * make_nda(daal::data_management::NumericTablePtr * nt_ptr);
-extern PyObject * make_nda(daal::data_management::KeyValueDataCollectionPtr * nt_ptr, const std::map< int64_t, std::string > &);
+extern PyObject * make_nda(daal::data_management::KeyValueDataCollectionPtr * nt_ptr, const i2str_map_t &);
 extern daal::data_management::NumericTablePtr * make_nt(PyObject * nda);
-extern daal::data_management::KeyValueDataCollectionPtr * make_dnt(PyObject * dict, std::map< std::string, int64_t > &);
+extern daal::data_management::KeyValueDataCollectionPtr * make_dnt(PyObject * dict, str2i_map_t &);
 
 extern const daal::data_management::NumericTablePtr readCSV(const std::string& fname);
 


### PR DESCRIPTION
@oleksandr-pavlyk 
* Fixing #23 by using correct string2enum hash
* throwing exception if invalid string is provided
* replacing std::map with faster std::unordered_map