### PR TITLE
Modelbuilder

### DIFF
--- a/generator/gen_daal4py.py
+++ b/generator/gen_daal4py.py
@@ -948,7 +948,10 @@ def gen_daal4py(daalroot, outdir, version, warn_all=False, no_dist=False, no_str
 
     with open(jp('src', 'gettree.pyx'), 'r') as f:
         pyx_gettree = f.read()
+    with open(jp('src', 'modelbuilder.pyx'), 'r') as f:
+        pyx_modelbuilder = f.read()
 
     with open(jp(outdir, 'daal4py_cy.pyx'), 'w') as f:
         f.write(pyx_file)
         f.write(pyx_gettree)
+        f.write(pyx_modelbuilder)

--- a/generator/wrappers.py
+++ b/generator/wrappers.py
@@ -21,7 +21,7 @@ from collections import defaultdict, OrderedDict, namedtuple
 def wrap_algo(algo, ver):
     #return True if 'kmeans' in algo and not 'interface' in algo else False
     # Ignore some algos if using older DAAL
-    if ver < (2019, 4) and any(x in algo for x in ['stump', 'adaboost', 'brownboost', 'logitboost',]):
+    if ver < (2019, 5) and any(x in algo for x in ['stump', 'adaboost', 'brownboost', 'logitboost',]):
         return False
     # ignore deprecated version of stump
     if 'stump' in algo and not any(x in algo for x in ['stump::regression', 'stump::classification']):

--- a/src/modelbuilder.h
+++ b/src/modelbuilder.h
@@ -5,3 +5,9 @@ typedef c_decision_forest_classification_ModelBuilder::NodeId c_NodeId;
 typedef c_decision_forest_classification_ModelBuilder::TreeId c_TreeId;
 
 #define c_noParent c_decision_forest_classification_ModelBuilder::noParent
+
+static daal::algorithms::decision_forest::classification::ModelPtr *
+get_decision_forest_classification_modelbuilder_Model(daal::algorithms::decision_forest::classification::ModelBuilder * obj_)
+{
+    return RAW< daal::algorithms::decision_forest::classification::ModelPtr >()(obj_->getModel());
+}

--- a/src/modelbuilder.h
+++ b/src/modelbuilder.h
@@ -1,0 +1,7 @@
+#include <daal.h>
+
+typedef daal::algorithms::decision_forest::classification::ModelBuilder c_decision_forest_classification_ModelBuilder;
+typedef c_decision_forest_classification_ModelBuilder::NodeId c_NodeId;
+typedef c_decision_forest_classification_ModelBuilder::TreeId c_TreeId;
+
+#define c_noParent c_decision_forest_classification_ModelBuilder::noParent

--- a/src/modelbuilder.pyx
+++ b/src/modelbuilder.pyx
@@ -22,16 +22,16 @@ cdef class decision_forest_classification_modelbuilder:
     def __dealloc__(self):
         del self.c_ptr
 
-    def createTree(self, size_t nNodes):
+    def create_tree(self, size_t nNodes):
         return self.c_ptr.createTree(nNodes)
 
-    def addLeafNode(self, c_TreeId treeId, c_NodeId parentId, size_t position, size_t classLabel):
+    def add_leaf(self, c_TreeId treeId, size_t classLabel, c_NodeId parentId=c_noParent, size_t position=0):
         return self.c_ptr.addLeafNode(treeId, parentId, position, classLabel)
 
-    def addSplitNode(self, c_TreeId treeId, size_t position, size_t featureIndex, double featureValue, c_NodeId parentId=c_noParent):
+    def add_split(self, c_TreeId treeId, size_t featureIndex, double featureValue, c_NodeId parentId=c_noParent, size_t position=0):
         return self.c_ptr.addSplitNode(treeId, parentId, position, featureIndex, featureValue)
 
-    def getModel(self):
+    def model(self):
         cdef decision_forest_classification_model res = decision_forest_classification_model.__new__(decision_forest_classification_model)
         res.c_ptr = get_decision_forest_classification_modelbuilder_Model(self.c_ptr)
         return res

--- a/src/modelbuilder.pyx
+++ b/src/modelbuilder.pyx
@@ -1,4 +1,4 @@
-cdef extern "modelbuilder.h":
+cdef extern from "modelbuilder.h":
     ctypedef size_t c_NodeId
     ctypedef size_t c_TreeId
     cdef size_t c_noParent
@@ -21,16 +21,16 @@ cdef class decision_forest_classification_modelbuilder:
     def __dealloc__(self):
         del self.c_ptr
 
-    def createTree(self, size_t nNodes)
+    def createTree(self, size_t nNodes):
         return self.c_ptr.createTree(nNodes)
 
-    def addLeafNode(self, c_TreeId treeId, c_NodeId parentId, size_t position, size_t classLabel)
-        return self.c_ptr.createTree(treeId, parentId, position, classLabel)
+    def addLeafNode(self, c_TreeId treeId, c_NodeId parentId, size_t position, size_t classLabel):
+        return self.c_ptr.addLeafMode(treeId, parentId, position, classLabel)
 
-    def addSplitNode(self, c_TreeId treeId, size_t position, size_t featureIndex, double featureValue, c_NodeId parentId=c_noParent)
-        return self.c_ptr.createTree(treeId, parentId, position, featureIndex, featureValue)
+    def addSplitNode(self, c_TreeId treeId, size_t position, size_t featureIndex, double featureValue, c_NodeId parentId=c_noParent):
+        return self.c_ptr.addSplitNode(treeId, parentId, position, featureIndex, featureValue)
 
-    def getModel(self)
+    def getModel(self):
         return self.c_ptr.getModel()
 
 

--- a/src/modelbuilder.pyx
+++ b/src/modelbuilder.pyx
@@ -1,0 +1,42 @@
+cdef extern "modelbuilder.h":
+    ctypedef size_t c_NodeId
+    ctypedef size_t c_TreeId
+    cdef size_t c_noParent
+
+    cdef cppclass c_decision_forest_classification_ModelBuilder:
+        ModelBuilder(size_t nClasses, size_t nTrees) except +
+        c_TreeId createTree(size_t nNodes)
+        c_NodeId addLeafNode(c_TreeId treeId, c_NodeId parentId, size_t position, size_t classLabel)
+        c_NodeId addSplitNode(c_TreeId treeId, c_NodeId parentId, size_t position, size_t featureIndex, double featureValue)
+        ModelPtr getModel()
+
+
+cdef class decision_forest_classification_modelbuilder:
+
+    cdef c_decision_forest_classification_ModelBuilder * c_ptr
+
+    def __cinit__(self, size_t nClasses, size_t nTrees):
+        self.c_ptr = new c_decision_forest_classification_ModelBuilder(nClasses, nTrees)
+
+    def __dealloc__(self):
+        del self.c_ptr
+
+    def createTree(self, size_t nNodes)
+        return self.c_ptr.createTree(nNodes)
+
+    def addLeafNode(self, c_TreeId treeId, c_NodeId parentId, size_t position, size_t classLabel)
+        return self.c_ptr.createTree(treeId, parentId, position, classLabel)
+
+    def addSplitNode(self, c_TreeId treeId, size_t position, size_t featureIndex, double featureValue, c_NodeId parentId=c_noParent)
+        return self.c_ptr.createTree(treeId, parentId, position, featureIndex, featureValue)
+
+    def getModel(self)
+        return self.c_ptr.getModel()
+
+
+def ModelBuilder(nTrees=1, nClasses=2):
+    '''
+    Currently we support only decision forest classification models.
+    The future may bring us more.
+    '''
+    return decision_forest_classification_modelbuilder(nClasses, nTrees)

--- a/src/modelbuilder.pyx
+++ b/src/modelbuilder.pyx
@@ -4,11 +4,12 @@ cdef extern from "modelbuilder.h":
     cdef size_t c_noParent
 
     cdef cppclass c_decision_forest_classification_ModelBuilder:
-        ModelBuilder(size_t nClasses, size_t nTrees) except +
+        c_decision_forest_classification_ModelBuilder(size_t nClasses, size_t nTrees) except +
         c_TreeId createTree(size_t nNodes)
         c_NodeId addLeafNode(c_TreeId treeId, c_NodeId parentId, size_t position, size_t classLabel)
         c_NodeId addSplitNode(c_TreeId treeId, c_NodeId parentId, size_t position, size_t featureIndex, double featureValue)
-        ModelPtr getModel()
+
+    cdef decision_forest_classification_ModelPtr * get_decision_forest_classification_modelbuilder_Model(c_decision_forest_classification_ModelBuilder *);
 
 
 cdef class decision_forest_classification_modelbuilder:
@@ -31,7 +32,9 @@ cdef class decision_forest_classification_modelbuilder:
         return self.c_ptr.addSplitNode(treeId, parentId, position, featureIndex, featureValue)
 
     def getModel(self):
-        return self.c_ptr.getModel()
+        cdef decision_forest_classification_model res = decision_forest_classification_model.__new__(decision_forest_classification_model)
+        res.c_ptr = get_decision_forest_classification_modelbuilder_Model(self.c_ptr)
+        return res
 
 
 def model_builder(nTrees=1, nClasses=2):

--- a/src/modelbuilder.pyx
+++ b/src/modelbuilder.pyx
@@ -25,7 +25,7 @@ cdef class decision_forest_classification_modelbuilder:
         return self.c_ptr.createTree(nNodes)
 
     def addLeafNode(self, c_TreeId treeId, c_NodeId parentId, size_t position, size_t classLabel):
-        return self.c_ptr.addLeafMode(treeId, parentId, position, classLabel)
+        return self.c_ptr.addLeafNode(treeId, parentId, position, classLabel)
 
     def addSplitNode(self, c_TreeId treeId, size_t position, size_t featureIndex, double featureValue, c_NodeId parentId=c_noParent):
         return self.c_ptr.addSplitNode(treeId, parentId, position, featureIndex, featureValue)

--- a/src/modelbuilder.pyx
+++ b/src/modelbuilder.pyx
@@ -34,7 +34,7 @@ cdef class decision_forest_classification_modelbuilder:
         return self.c_ptr.getModel()
 
 
-def ModelBuilder(nTrees=1, nClasses=2):
+def model_builder(nTrees=1, nClasses=2):
     '''
     Currently we support only decision forest classification models.
     The future may bring us more.


### PR DESCRIPTION
@Alexander-Makaryev @oleksandr-pavlyk 

The modelbuilder's method names are all lower case with '_' instead of camel-case to align with the rest of daal4py.

Also, I made parent and position optional keyword args, users can then add root nodes more easily.