### PR TITLE
Sklearn 0.20.3 update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,9 +50,9 @@ jobs:
             # test_k_means_fit_predict is known to sporadically fail for float32 inputs in multithreaded runs
             # See: https://github.com/IntelPython/daal4py/issues/25
             export DESELECTED_TESTS="${DESELECTED_TESTS} --deselect ${BASEDIR}cluster/tests/test_k_means.py::test_k_means_fit_predict"
-	    # test_non_uniform_strategies fails due to differences in handling of vacuous clusters after update
-	    # htSee tps://github.com/IntelPython/daal4py/issues/69
-	    export DESELECTED_TESTS="${DESELECTED_TESTS} --deselect ${BASEDIR}preprocessing/tests/test_discretization.py::test_nonuniform_strategies"
+            # test_non_uniform_strategies fails due to differences in handling of vacuous clusters after update
+            # htSee tps://github.com/IntelPython/daal4py/issues/69
+            export DESELECTED_TESTS="${DESELECTED_TESTS} --deselect ${BASEDIR}preprocessing/tests/test_discretization.py::test_nonuniform_strategies"
             echo "-m daal4py -m pytest ${DESELECTED_TESTS} -q -ra --disable-warnings --pyargs sklearn"
             # It is important for pytest to work in a separate test folder to not discover tests in ~/miniconda folder
             cd && ((python -m daal4py -m pytest ${DESELECTED_TESTS} -ra --disable-warnings --pyargs sklearn | tee ~/d4p.out) || true)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,6 +50,9 @@ jobs:
             # test_k_means_fit_predict is known to sporadically fail for float32 inputs in multithreaded runs
             # See: https://github.com/IntelPython/daal4py/issues/25
             export DESELECTED_TESTS="${DESELECTED_TESTS} --deselect ${BASEDIR}cluster/tests/test_k_means.py::test_k_means_fit_predict"
+	    # test_non_uniform_strategies fails due to differences in handling of vacuous clusters after update
+	    # htSee tps://github.com/IntelPython/daal4py/issues/69
+	    export DESELECTED_TESTS="${DESELECTED_TESTS} --deselect ${BASEDIR}preprocessing/tests/test_discretization.py::test_nonuniform_strategies"
             echo "-m daal4py -m pytest ${DESELECTED_TESTS} -q -ra --disable-warnings --pyargs sklearn"
             # It is important for pytest to work in a separate test folder to not discover tests in ~/miniconda folder
             cd && ((python -m daal4py -m pytest ${DESELECTED_TESTS} -ra --disable-warnings --pyargs sklearn | tee ~/d4p.out) || true)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,12 +35,12 @@ jobs:
             export PATH=~/miniconda/bin:$PATH
             . ~/miniconda/etc/profile.d/conda.sh
             conda activate bld
-	    conda install -c defaults pyyaml
+            conda install -c defaults pyyaml
             conda install -q /tmp/out/*/daal4py-*.tar.bz2
             pip install -q scikit-learn
             conda list
             touch ~/d4p.out ~/skl.out
-	    export DESELECTED_TESTS=`python deselect_tests.py ../deselected_tests.yaml --absolute`
+            export DESELECTED_TESTS=`python deselect_tests.py ../deselected_tests.yaml --absolute`
             echo "-m daal4py -m pytest ${DESELECTED_TESTS} -q -ra --disable-warnings --pyargs sklearn"
             # It is important for pytest to work in a separate test folder to not discover tests in ~/miniconda folder
             cd && ((python -m daal4py -m pytest ${DESELECTED_TESTS} -ra --disable-warnings --pyargs sklearn | tee ~/d4p.out) || true)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,24 +35,12 @@ jobs:
             export PATH=~/miniconda/bin:$PATH
             . ~/miniconda/etc/profile.d/conda.sh
             conda activate bld
+	    conda install -c defaults pyyaml
             conda install -q /tmp/out/*/daal4py-*.tar.bz2
             pip install -q scikit-learn
             conda list
             touch ~/d4p.out ~/skl.out
-            export BASEDIR=`python -c "import os.path, sklearn; print(os.path.relpath(os.path.dirname(sklearn.__file__), os.path.expanduser('~')) + '/')"`
-            # Deselecting 5 SVC related tests where duplicate samples end up being support vectors
-            # See: https://github.com/scikit-learn/scikit-learn/issues/12738
-            export DESELECTED_TESTS="--deselect ${BASEDIR}svm/tests/test_svm.py::test_sample_weights"
-            export DESELECTED_TESTS="${DESELECTED_TESTS} --deselect ${BASEDIR}svm/tests/test_svm.py::test_precomputed"
-            export DESELECTED_TESTS="${DESELECTED_TESTS} --deselect ${BASEDIR}svm/tests/test_sparse.py::test_sparse"
-            export DESELECTED_TESTS="${DESELECTED_TESTS} --deselect ${BASEDIR}svm/tests/test_sparse.py::test_svc_iris"
-            export DESELECTED_TESTS="${DESELECTED_TESTS} --deselect ${BASEDIR}ensemble/tests/test_bagging.py::test_sparse_classification"
-            # test_k_means_fit_predict is known to sporadically fail for float32 inputs in multithreaded runs
-            # See: https://github.com/IntelPython/daal4py/issues/25
-            export DESELECTED_TESTS="${DESELECTED_TESTS} --deselect ${BASEDIR}cluster/tests/test_k_means.py::test_k_means_fit_predict"
-            # test_non_uniform_strategies fails due to differences in handling of vacuous clusters after update
-            # htSee tps://github.com/IntelPython/daal4py/issues/69
-            export DESELECTED_TESTS="${DESELECTED_TESTS} --deselect ${BASEDIR}preprocessing/tests/test_discretization.py::test_nonuniform_strategies"
+	    export DESELECTED_TESTS=`python deselect_tests.py ../deselected_tests.yaml --absolute`
             echo "-m daal4py -m pytest ${DESELECTED_TESTS} -q -ra --disable-warnings --pyargs sklearn"
             # It is important for pytest to work in a separate test folder to not discover tests in ~/miniconda folder
             cd && ((python -m daal4py -m pytest ${DESELECTED_TESTS} -ra --disable-warnings --pyargs sklearn | tee ~/d4p.out) || true)

--- a/.circleci/deselect_tests.py
+++ b/.circleci/deselect_tests.py
@@ -16,9 +16,9 @@ def evaluate_cond(cond, v):
     if cond.startswith("!="):
         return LooseVersion(v) != LooseVersion(cond[2:])
     if cond.startswith("<"):
-        return LooseVersion(v) < LooseVersion(cond[2:])
+        return LooseVersion(v) < LooseVersion(cond[1:])
     if cond.startswith(">"):
-        return LooseVersion(v) > LooseVersion(cond[2:])
+        return LooseVersion(v) > LooseVersion(cond[1:])
     return False
     
 

--- a/.circleci/deselect_tests.py
+++ b/.circleci/deselect_tests.py
@@ -5,6 +5,7 @@ from yaml import load as yaml_load
 from distutils.version import LooseVersion
 import sklearn
 from sklearn import __version__ as sklearn_version
+import warnings
 
 def evaluate_cond(cond, v):
     if cond.startswith(">="):
@@ -19,6 +20,7 @@ def evaluate_cond(cond, v):
         return LooseVersion(v) < LooseVersion(cond[1:])
     if cond.startswith(">"):
         return LooseVersion(v) > LooseVersion(cond[1:])
+    warnings.warn('Test selection condition "{0}" should start with >=, <=, ==, !=, < or > to compare to version of scikit-learn run. The test will not be deselected'.format(cond))
     return False
     
 

--- a/.circleci/deselect_tests.py
+++ b/.circleci/deselect_tests.py
@@ -1,0 +1,28 @@
+# coding: utf-8
+import argparse
+import os.path
+from yaml import load as yaml_load
+
+if __name__ == '__main__':
+    argParser = argparse.ArgumentParser(
+        prog="deselect_tests.py",
+        description="Produce pytest CLI options to deselect tests specified in yaml file",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+    argParser.add_argument('conf_file', nargs=1, type=str)
+    argParser.add_argument('--absolute', action='store_true')
+
+    args = argParser.parse_args()
+
+    fn = args.conf_file[0] 
+    if os.path.exists(fn):
+        with open(fn, 'r') as fh:
+            dt = yaml_load(fh)
+
+        if args.absolute:
+            import sklearn
+            base_dir = os.path.relpath(os.path.dirname(sklearn.__file__), os.path.expanduser('~')) + '/'
+        else:
+            base_dir = ""
+
+        print(" ".join([ "--deselect " + base_dir + test_name for test_name in dt.get('deselected_tests', []) ]))

--- a/daal4py/sklearn/monkeypatch/dispatcher.py
+++ b/daal4py/sklearn/monkeypatch/dispatcher.py
@@ -74,8 +74,10 @@ def do_unpatch(name):
 def enable(name=None):
     if LooseVersion(sklearn_version) < LooseVersion("0.20.0"):
         raise NotImplementedError("daal4sklearn is for scikit-learn 0.20.0 only ...")
-    elif LooseVersion(sklearn_version) > LooseVersion("0.20.2"):
-        warnings.warn("daal4sklearn {daal4py_version} has only been tested with scikit-learn 0.20.2, found version...")
+    elif LooseVersion(sklearn_version) > LooseVersion("0.20.3"):
+        warn_msg = ("daal4py {daal4py_version} has only been tested " +
+                   "with scikit-learn 0.20.3, found version: {sklearn_version}")
+        warnings.warn(warn_msg.format(daal4py_version=daal4py.__version__, sklearn_version=sklearn_version))
 
     if name is not None:
         do_patch(name)

--- a/daal4py/sklearn/monkeypatch/svm.py
+++ b/daal4py/sklearn/monkeypatch/svm.py
@@ -278,6 +278,17 @@ def _daal_var(X):
 
 
 def __compute_gamma__(gamma, kernel, X, sparse, use_var=True):
+    """
+    Computes actual value of 'gamma' parameter of RBF kernel
+    corresponding to SVC keyword values `gamma` and `kernel`, and feature 
+    matrix X, with sparsity `sparse`.
+
+    In 0.20 gamma='scale' used to mean compute 'gamma' based on 
+    column-wise standard deviation, but in 0.20.3 it was changed
+    to use column-wise variance.
+
+    See: https://github.com/scikit-learn/scikit-learn/pull/13221 
+    """
     if gamma in ('scale', 'auto_deprecated'):
         kernel_uses_gamma = (not callable(kernel) and kernel
                              not in ('linear', 'precomputed'))

--- a/daal4py/sklearn/monkeypatch/svm.py
+++ b/daal4py/sklearn/monkeypatch/svm.py
@@ -24,6 +24,10 @@ from sklearn.utils import check_random_state, check_X_y
 import sklearn.svm.classes
 import warnings
 
+from distutils.version import LooseVersion
+from sklearn import __version__ as sklearn_version
+
+
 import daal4py
 from ..utils import (make2d, getFPType)
 
@@ -273,6 +277,86 @@ def _daal_var(X):
     return ssc[0, 0] / X.size
 
 
+
+"""
+        if self.gamma in ('scale', 'auto_deprecated'):
+            if sparse:
+                # var = E[X^2] - E[X]^2
+                X_var = (X.multiply(X)).mean() - (X.mean()) ** 2
+            else:
+                X_var = X.var()
+            if self.gamma == 'scale':
+                if X_var != 0:
+                    self._gamma = 1.0 / (X.shape[1] * X_var)
+                else:
+                    self._gamma = 1.0
+            else:
+                kernel_uses_gamma = (not callable(self.kernel) and self.kernel
+                                     not in ('linear', 'precomputed'))
+                if kernel_uses_gamma and not np.isclose(X_var, 1.0):
+                    # NOTE: when deprecation ends we need to remove explicitly
+                    # setting `gamma` in examples (also in tests). See
+                    # https://github.com/scikit-learn/scikit-learn/pull/10331
+                    # for the examples/tests that need to be reverted.
+                    warnings.warn("The default value of gamma will change "
+                                  "from 'auto' to 'scale' in version 0.22 to "
+                                  "account better for unscaled features. Set "
+                                  "gamma explicitly to 'auto' or 'scale' to "
+                                  "avoid this warning.", FutureWarning)
+                self._gamma = 1.0 / X.shape[1]
+        elif self.gamma == 'auto':
+            self._gamma = 1.0 / X.shape[1]
+        else:
+            self._gamma = self.gamma
+"""
+
+def __compute_gamma__(gamma, kernel, X, sparse, use_var=True):
+    if gamma in ('scale', 'auto_deprecated'):
+        kernel_uses_gamma = (not callable(kernel) and kernel
+                             not in ('linear', 'precomputed'))
+        if kernel_uses_gamma:
+            if sparse:
+                # var = E[X^2] - E[X]^2
+                X_sc = (X.multiply(X)).mean() - (X.mean())**2
+            else:
+                X_sc = _daal_var(X) # X.var()
+            if not use_var:
+                X_sc = np.sqrt(X_sc)
+        else:
+            X_sc = 1.0 / X.shape[1]
+        if gamma == 'scale':
+            if X_sc != 0:
+                _gamma = 1.0 / (X.shape[1] * X_sc)
+            else:
+                _gamma = 1.0
+        else:
+            if kernel_uses_gamma and not np.isclose(X_sc, 1.0):
+                # NOTE: when deprecation ends we need to remove explicitly
+                # setting `gamma` in examples (also in tests). See
+                # https://github.com/scikit-learn/scikit-learn/pull/10331
+                # for the examples/tests that need to be reverted.
+                warnings.warn("The default value of gamma will change "
+                              "from 'auto' to 'scale' in version 0.22 to "
+                              "account better for unscaled features. Set "
+                              "gamma explicitly to 'auto' or 'scale' to "
+                              "avoid this warning.", FutureWarning)
+            _gamma = 1.0 / X.shape[1]
+    elif gamma == 'auto':
+        _gamma = 1.0 / X.shape[1]
+    else:
+        _gamma = gamma
+
+    return _gamma
+
+no_older_than_0_20_3 = None
+
+def _compute_gamma(*args):
+    global no_older_than_0_20_3
+    if no_older_than_0_20_3 is None:
+        no_older_than_0_20_3 = (LooseVersion(sklearn_version) >= LooseVersion("0.20.3"))
+    return __compute_gamma__(*args, use_var=no_older_than_0_20_3)
+
+
 def fit(self, X, y, sample_weight=None):
         """Fit the SVM model according to the given training data.
 
@@ -336,39 +420,7 @@ def fit(self, X, y, sample_weight=None):
                              "boolean masks (use `indices=True` in CV)."
                              % (sample_weight.shape, X.shape))
 
-        if self.gamma in ('scale', 'auto_deprecated'):
-            kernel_uses_gamma = (not callable(self.kernel) and self.kernel
-                                 not in ('linear', 'precomputed'))
-            if kernel_uses_gamma:
-                if sparse:
-                    # std = E[X^2] - E[X]^2
-                    X_var = X.multiply(X).mean() - (X.mean())**2
-                else:
-                    X_var = _daal_var(X) # X.var()
-            else:
-                X_var = 1.0 / X.shape[1]
-            if self.gamma == 'scale':
-                if X_var != 0:
-                    self._gamma = 1.0 / (X.shape[1] * X_var)
-                else:
-                    self._gamma = 1.0
-            else:
-                if kernel_uses_gamma and not np.isclose(X_var, 1.0):
-                    # NOTE: when deprecation ends we need to remove explicitly
-                    # setting `gamma` in examples (also in tests). See
-                    # https://github.com/scikit-learn/scikit-learn/pull/10331
-                    # for the examples/tests that need to be reverted.
-                    warnings.warn("The default value of gamma will change "
-                                  "from 'auto' to 'scale' in version 0.22 to "
-                                  "account better for unscaled features. Set "
-                                  "gamma explicitly to 'auto' or 'scale' to "
-                                  "avoid this warning.", FutureWarning)
-                self._gamma = 1.0 / X.shape[1]
-        elif self.gamma == 'auto':
-            self._gamma = 1.0 / X.shape[1]
-        else:
-            self._gamma = self.gamma
-
+        self._gamma = _compute_gamma(self.gamma, self.kernel, X, sparse)
 
         kernel = self.kernel
         if callable(kernel):

--- a/daal4py/sklearn/monkeypatch/svm.py
+++ b/daal4py/sklearn/monkeypatch/svm.py
@@ -277,39 +277,6 @@ def _daal_var(X):
     return ssc[0, 0] / X.size
 
 
-
-"""
-        if self.gamma in ('scale', 'auto_deprecated'):
-            if sparse:
-                # var = E[X^2] - E[X]^2
-                X_var = (X.multiply(X)).mean() - (X.mean()) ** 2
-            else:
-                X_var = X.var()
-            if self.gamma == 'scale':
-                if X_var != 0:
-                    self._gamma = 1.0 / (X.shape[1] * X_var)
-                else:
-                    self._gamma = 1.0
-            else:
-                kernel_uses_gamma = (not callable(self.kernel) and self.kernel
-                                     not in ('linear', 'precomputed'))
-                if kernel_uses_gamma and not np.isclose(X_var, 1.0):
-                    # NOTE: when deprecation ends we need to remove explicitly
-                    # setting `gamma` in examples (also in tests). See
-                    # https://github.com/scikit-learn/scikit-learn/pull/10331
-                    # for the examples/tests that need to be reverted.
-                    warnings.warn("The default value of gamma will change "
-                                  "from 'auto' to 'scale' in version 0.22 to "
-                                  "account better for unscaled features. Set "
-                                  "gamma explicitly to 'auto' or 'scale' to "
-                                  "avoid this warning.", FutureWarning)
-                self._gamma = 1.0 / X.shape[1]
-        elif self.gamma == 'auto':
-            self._gamma = 1.0 / X.shape[1]
-        else:
-            self._gamma = self.gamma
-"""
-
 def __compute_gamma__(gamma, kernel, X, sparse, use_var=True):
     if gamma in ('scale', 'auto_deprecated'):
         kernel_uses_gamma = (not callable(kernel) and kernel

--- a/deselected_tests.yaml
+++ b/deselected_tests.yaml
@@ -1,4 +1,15 @@
+# This file lists node ids (in pytest sense) of sklearn tests that
+# are to be deselected during test discovery step.
+#
+# Deselection can be predicated on the version of scikit-learn used.
+# Use - node_id cond, or - node_id cond1,cond2  where cond is OPver.
+# Supported OPs are >=, <=, ==, !=, >, <
+# For example,
+#    - tests/test_isotonic.py::test_permutation_invariance >0.18,<=0.19
+#  will exclude deselection in versions 0.18.1, and 0.18.2 only
+
 deselected_tests:
+
   # Deselecting 5 SVC related tests where duplicate samples end up being support vectors
   # See: https://github.com/scikit-learn/scikit-learn/issues/12738
   - svm/tests/test_svm.py::test_sample_weights
@@ -6,9 +17,11 @@ deselected_tests:
   - svm/tests/test_sparse.py::test_sparse
   - svm/tests/test_sparse.py::test_svc_iris
   - ensemble/tests/test_bagging.py::test_sparse_classification
+
   # test_k_means_fit_predict is known to sporadically fail for float32 inputs in multithreaded runs
   # See: https://github.com/IntelPython/daal4py/issues/25
   - cluster/tests/test_k_means.py::test_k_means_fit_predict
+
   # test_non_uniform_strategies fails due to differences in handling of vacuous clusters after update
   # See https://github.com/IntelPython/daal4py/issues/69
   - preprocessing/tests/test_discretization.py::test_nonuniform_strategies >=0.20.3

--- a/deselected_tests.yaml
+++ b/deselected_tests.yaml
@@ -11,4 +11,4 @@ deselected_tests:
   - cluster/tests/test_k_means.py::test_k_means_fit_predict
   # test_non_uniform_strategies fails due to differences in handling of vacuous clusters after update
   # See https://github.com/IntelPython/daal4py/issues/69
-  - preprocessing/tests/test_discretization.py::test_nonuniform_strategies
+  - preprocessing/tests/test_discretization.py::test_nonuniform_strategies >=0.20.3

--- a/deselected_tests.yaml
+++ b/deselected_tests.yaml
@@ -1,0 +1,14 @@
+deselected_tests:
+  # Deselecting 5 SVC related tests where duplicate samples end up being support vectors
+  # See: https://github.com/scikit-learn/scikit-learn/issues/12738
+  - svm/tests/test_svm.py::test_sample_weights
+  - svm/tests/test_svm.py::test_precomputed
+  - svm/tests/test_sparse.py::test_sparse
+  - svm/tests/test_sparse.py::test_svc_iris
+  - ensemble/tests/test_bagging.py::test_sparse_classification
+  # test_k_means_fit_predict is known to sporadically fail for float32 inputs in multithreaded runs
+  # See: https://github.com/IntelPython/daal4py/issues/25
+  - cluster/tests/test_k_means.py::test_k_means_fit_predict
+  # test_non_uniform_strategies fails due to differences in handling of vacuous clusters after update
+  # See https://github.com/IntelPython/daal4py/issues/69
+  - preprocessing/tests/test_discretization.py::test_nonuniform_strategies


### PR DESCRIPTION
Updated scikit-learn patches to work with scikit-learn 0.20.3

Also, deselected tests are now specified in `./deselected_tests.yaml`, which is parsed and transfored into sequence of `--deselect` commands in a Python script.

@fschlimb 