### PR TITLE
Free tree state arrays

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -128,9 +128,6 @@ def getpyexts():
     eca += get_sdl_cflags()
     ela += get_sdl_ldflags()
 
-    if sys.version_info[0] >= 3:
-        eca.append('-DUSE_CAPSULE')
-
     if IS_WIN:
         libraries_plat = ['daal_core_dll']
     else:

--- a/src/daal4py.cpp
+++ b/src/daal4py.cpp
@@ -81,14 +81,14 @@ void daalsp_free(void * cap)
 #ifdef USE_CAPSULE
 void rawp_free_cap(PyObject * cap)
 {
-    VSP * sp = (VSP*) PyCapsule_GetPointer(cap, NULL);
-    if (sp) delete sp;
+    void * rp = PyCapsule_GetPointer(cap, NULL);
+    if (rp) delete[] rp;
 }
 #else
 void rawp_free(void * cap)
 {
-    VSP * sp = (VSP*) PyCObject_AsVoidPtr(reinterpret_cast<PyObject *>(cap));
-    if (sp) delete sp;
+    void * rp = PyCObject_AsVoidPtr(reinterpret_cast<PyObject *>(cap));
+    if (rp) delete[] rp;
 }
 #endif
 

--- a/src/daal4py.cpp
+++ b/src/daal4py.cpp
@@ -63,43 +63,23 @@ private:
 };
 
 // define our own free functions for wrapping python objects holding our shared pointers
-#ifdef USE_CAPSULE
 void daalsp_free_cap(PyObject * cap)
 {
     VSP * sp = (VSP*) PyCapsule_GetPointer(cap, NULL);
     if (sp) delete sp;
 }
-#else
-void daalsp_free(void * cap)
-{
-    VSP * sp = (VSP*) PyCObject_AsVoidPtr(reinterpret_cast<PyObject *>(cap));
-    if (sp) delete sp;
-}
-#endif
 
 // define our own free functions for wrapping python objects holding our raw pointers
-#ifdef USE_CAPSULE
 void rawp_free_cap(PyObject * cap)
 {
     void * rp = PyCapsule_GetPointer(cap, NULL);
     if (rp) delete[] rp;
 }
-#else
-void rawp_free(void * cap)
-{
-    void * rp = PyCObject_AsVoidPtr(reinterpret_cast<PyObject *>(cap));
-    if (rp) delete[] rp;
-}
-#endif
 
 
 void set_rawp_base(PyArrayObject * ary, void * ptr)
 {
-#ifdef USE_CAPSULE
     PyObject* cap = PyCapsule_New(ptr, NULL, rawp_free_cap);
-#else
-    PyObject* cap = PyCObject_FromVoidPtr(ptr, rawp_free);
-#endif
     PyArray_SetBaseObject(ary, cap);
 }
 

--- a/src/daal4py.h
+++ b/src/daal4py.h
@@ -303,6 +303,9 @@ void set_sp_base(PyArrayObject * ary, daal::services::SharedPtr<T> & sp)
     PyArray_SetBaseObject(ary, cap);
 }
 
-extern void set_rawp_base(PyArrayObject *, void *);
+
+extern "C" {
+void set_rawp_base(PyArrayObject *, void *);
+}
 
 #endif // _HLAPI_H_INCLUDED_

--- a/src/daal4py.h
+++ b/src/daal4py.h
@@ -283,23 +283,14 @@ public:
 };
 
 // define our own free functions for wrapping python objects holding our shared pointers
-#ifdef USE_CAPSULE
 extern void daalsp_free_cap(PyObject *);
 extern void rawp_free_cap(PyObject *);
-#else
-extern void daalsp_free(void *);
-extern void rawp_free(void *);
-#endif
 
 template< typename T >
 void set_sp_base(PyArrayObject * ary, daal::services::SharedPtr<T> & sp)
 {
     void * tmp_sp = (void*) new TVSP<T>(sp);
-#ifdef USE_CAPSULE
     PyObject* cap = PyCapsule_New(tmp_sp, NULL, daalsp_free_cap);
-#else
-    PyObject* cap = PyCObject_FromVoidPtr(tmp_sp, daalsp_free);
-#endif
     PyArray_SetBaseObject(ary, cap);
 }
 

--- a/src/daal4py.h
+++ b/src/daal4py.h
@@ -287,7 +287,7 @@ public:
 extern void daalsp_free_cap(PyObject *);
 extern void rawp_free_cap(PyObject *);
 #else
-extern void daalsp_free(PyObject *);
+extern void daalsp_free(void *);
 extern void rawp_free(void *);
 #endif
 

--- a/src/daal4py.h
+++ b/src/daal4py.h
@@ -287,7 +287,7 @@ public:
 extern void daalsp_free_cap(PyObject *);
 extern void rawp_free_cap(PyObject *);
 #else
-extern void daalsp_free_cap(PyObject *);
+extern void daalsp_free(PyObject *);
 extern void rawp_free(void *);
 #endif
 


### PR DESCRIPTION
Since PyCObject is [deprecated](https://docs.python.org/2/c-api/cobject.html) even in Py 2.7 we should always use PyCapsule.

NumPy arrays associated with pyTreeState recorded their base as the instance of the class itself, but destructor of the class was not freeing C arrays allocated in SKLearnTreeVisitor. 

The base is now being set to a Capsule object associated with the C pointer and its destructor, ensuring that the memory gets freed.

Using the following script:

```python
import os
import psutil
process = psutil.Process(os.getpid())
print(process.memory_info().rss)
for i in range(1000):
    tree_state = daal4py.getTreeState(dec_tree_model, n_classes=n_classes)
    del tree_state
print(process.memory_info().rss)
```

for a certain decision tree model in `tetrahedral_dtc.py` example, I was previously
getting

```text
(daal_adaboost) [10:28:54 fxsatlin03 adaboost_examples]$ python tetrahedral_dtc.py
++++++ Daal with decision tree
Execution wall-time: 0.001
Node array for DAAL's decision tree
150622208
151605248
```

and now:

```
(def) [10:27:55 fxsatlin03 adaboost_examples]$ python tetrahedral_dtc.py
++++++ Daal with decision tree
Execution wall-time: 0.001
Node array for DAAL's decision tree
127377408
127377408
```

Intel(R) Inspector run on this code reports

ID  Type Sources Modules Object Size State
P5  Mismatched allocation/deallocation daal4py.cpp; tree_visitor.h _daal4py.cpython-36m-x86_64-linux-gnu.so  New

showing that memory is allocated in toSKLearnTreeNodeVisitor constructor, but deallocated in rawp_free_cap deleters
associated with the capsule storing pointers to the memory allocated in the constructor.

This could be done cleaner, but works as intended.