### PR TITLE
BUG: undo_patch should only reset to non None values

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,9 @@ jobs:
             conda config --set always_yes yes --set changeps1 no
             conda update -q conda
             conda install -q conda-build
-            conda create -q -n bld --override-channels -c intel -c conda-forge python=3.6 numpy scipy pytest daal mpich tbb pandas numpydoc
+            conda create -q -n bld --override-channels -c intel -c conda-forge python=3.6 numpy scipy pytest daal tbb pandas numpydoc
+            conda install -q -n bld -c defaults --override-channels --no-deps libgcc-ng libstdcxx-ng
+            conda install -q -n bld -c conda-forge --override-channels --no-deps mpi libgfortran mpich
             gcc -v
             g++ -v
             head /proc/cpuinfo

--- a/daal4py/sklearn/monkeypatch/dispatcher.py
+++ b/daal4py/sklearn/monkeypatch/dispatcher.py
@@ -65,8 +65,9 @@ def do_unpatch(name):
     lname = name.lower()
     if lname in _mapping:
         for descriptor in _mapping[lname]:
-            which, what, replacer = descriptor[0]
-            setattr(which, what, descriptor[1])
+            if descriptor[1] is not None:
+                which, what, replacer = descriptor[0]
+                setattr(which, what, descriptor[1])
     else:
         raise ValueError("Has no patch for: " + name)
 


### PR DESCRIPTION
@fschlimb @Alexander-Makaryev 

The following snippet now runs as expected:

```python
from daal4py.sklearn.monkeypatch import dispatcher
dispatcher.disable()

from sklearn.cluster import KMeans
kmeans = KMeans(n_clusters=20, random_state=42, algorithm="full", \
                max_iter=1000)
```

Previously, it would erroneously set `sklearn.cluster.KMeans` class
to `None`.