### PR TITLE
fixing mem leak

### DIFF
--- a/generator/format.py
+++ b/generator/format.py
@@ -63,7 +63,7 @@ def flat(typ):
 def cy_callext(arg, typ_cy, typ_cyext, s2e=None):
     '''Where needed decorate argument with conversion when calling C++ from cython'''
     if 'data_or_file' in typ_cy:
-        return 'mk_data_or_file({0})'.format(arg)
+        return 'data_or_file(<PyObject*>{0})'.format(arg)
     if 'dict_numerictable' in typ_cy:
         return 'make_dnt(<PyObject *>' + arg + ((', ' + s2e) if s2e else '') + ')'
     if 'list_numerictable' in typ_cy:
@@ -136,9 +136,8 @@ def mk_var(name='', typ='', const='', dflt=None, inpt=False, algo=None, doc=None
                 arg_c = d4pname
                 # arrays/tables need special handling for C: they are passed as (ptr, dim1, dim2)
                 if typ_cy == 'data_or_file':
-                    decl_c = 'double* {0}_p, size_t {0}_d2, size_t {0}_d1'.format(d4pname)
-                    arg_c = 'new data_or_file(daal::data_management::HomogenNumericTable< double >::create({0}_p, {0}_d2, {0}_d1))'.format(d4pname)
-                    const = ''
+                    decl_c = 'double* {0}_p, size_t {0}_nrows, size_t {0}_ncols, ssize_t {0}_layout'.format(d4pname)
+                    arg_c = 'data_or_file({0}_p, {0}_ncols, {0}_nrows, {0}_layout)'.format(d4pname)
                 # default values (see above pydefaults)
                 if dflt != None:
                     pd = (pydefaults[typ] if dflt == True else dflt).rsplit('::', 1)[-1]
@@ -155,6 +154,7 @@ def mk_var(name='', typ='', const='', dflt=None, inpt=False, algo=None, doc=None
             self.daalname      = name
             self.value         = value if name else ''
             self.typ_cpp       = typ if name else ''
+            self.get_obj       = '{0} = _get_data({0})'.format(d4pname) if 'data_or_file' in typ else ''
             self.arg_cpp       = d4pname
             self.arg_py        = d4pname
             self.arg_cyext     = cy_callext(d4pname, typ_cy, typ_cyext, s2e) if name else ''

--- a/generator/gen_daal4py.py
+++ b/generator/gen_daal4py.py
@@ -736,7 +736,7 @@ class cython_interface(object):
                             dflt = None
                         if '::NumericTablePtr' in itype:
                             #ns in has_dist and iname in has_dist[ns]['step_specs'][0].inputnames or iname in ['data', 'labels', 'dependentVariable', 'tableToFill']:
-                            itype = 'data_or_file *'
+                            itype = 'data_or_file &'
                         ins = re.sub(r'(?<!daal::)algorithms::', r'daal::algorithms::', ins)
                         tmp_input_args.insert(i, mk_var(ins + '::' + iname, itype, 'const', dflt, inpt=True, algo=func, doc=doc))
             else:

--- a/src/daal4py.cpp
+++ b/src/daal4py.cpp
@@ -313,7 +313,7 @@ daal::data_management::NumericTablePtr * make_nt(PyObject * obj)
 #define SETARRAY_(_T) {daal::services::SharedPtr< _T > _tmp(reinterpret_cast< _T * >(PyArray_DATA(ary)), NumpyDeleter(ary)); soatbl->setArray(_tmp, i);}
                     SET_NPY_FEATURE(PyArray_DESCR(ary)->type, SETARRAY_, throw std::invalid_argument("Found unsupported array type"));
 #undef SETARRAY_
-
+                    Py_INCREF(ary);
                 }
                 if(soatbl->getNumberOfColumns() != N) {
                     delete soatbl;

--- a/src/daal4py.h
+++ b/src/daal4py.h
@@ -162,8 +162,13 @@ struct data_or_file
 {
     mutable daal::data_management::NumericTablePtr table;
     std::string                                    file;
-    inline data_or_file(daal::data_management::NumericTablePtr t)
-        : table(t), file() {}
+    template<typename T>
+    inline data_or_file(T * ptr, size_t ncols, size_t nrows, ssize_t layout)
+        : table(), file()
+    {
+        if(layout > 0) throw std::invalid_argument("Supporting only homogeneous, contiguous arrays.");
+        table = daal::data_management::HomogenNumericTable<T>::create(ptr, ncols, nrows);
+    }
     inline data_or_file()
         : table(), file() {}
     data_or_file(PyObject *);
@@ -189,6 +194,7 @@ struct RAW< daal::services::SharedPtr< T > >
 template< typename T > T to_daal(T t) {return t;}
 template< typename T > daal::services::SharedPtr<T> to_daal(daal::services::SharedPtr<T>* t) {return *t;}
 inline const data_or_file & to_daal(const data_or_file * t) {return *t;}
+inline const data_or_file & to_daal(const data_or_file & t) {return t;}
 inline const data_or_file & to_daal(data_or_file * t) {return *t;}
 
 template< typename T >


### PR DESCRIPTION
@Alexander-Makaryev 
`get_dat_or_file` was allocating memory for the data_or_file wrapper which was never freed.
This was "hiding" a ref-count issue for SOA tables (e.g. when reading from pandas)