### PR TITLE
Adjusted patched vs. unpatched run comparator

### DIFF
--- a/.circleci/compare_runs.py
+++ b/.circleci/compare_runs.py
@@ -13,7 +13,8 @@ def comp(k, op):
 
 
 d4p, skl = get_counts('D4P'), get_counts('SKL')
-if all((comp('failed', operator.le), # patched has <= fails
+
+if d4p and skl and all((comp('failed', operator.le), # patched has <= fails
      comp('passed', operator.ge),    # patches has >= passes due to extra tests discovered
      comp('xpassed', operator.eq),
      comp('xfailed', operator.eq))

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,10 +81,7 @@ workflows:
   version: 2
   commit:
     jobs:
-      - build_pypi:
-          filters:
-            branches:
-              only: master
+      - build_pypi
 
   nightly:
     triggers:

--- a/deselected_tests.yaml
+++ b/deselected_tests.yaml
@@ -27,5 +27,5 @@ deselected_tests:
   - preprocessing/tests/test_discretization.py::test_nonuniform_strategies >=0.20.3
 
   # For Newton-CG solver, solution computed in float32 disagrees with that of float64 a little more than
-  # the test expects
+  # the test expects, see https://github.com/scikit-learn/scikit-learn/pull/13645
   - linear_model/tests/test_logistic.py::test_dtype_match


### PR DESCRIPTION
scripting comparing results of patched and unpatched test runs should expect that summary is non-empty.

Should change should make the button testing patches against the master of scikit-learn turn red. 

Once it does, the next step is to ensure that joblib is installed in the environment.

@fschlimb Can I trigger the master-check build manually?