### PR TITLE
Attempt to fix memory leak (issue 92)

### DIFF
--- a/generator/wrapper_gen.py
+++ b/generator/wrapper_gen.py
@@ -315,10 +315,13 @@ cdef class {{flatname}}:
         '''
         if not is_valid_ptrptr(self.c_ptr):
             raise ValueError("Pointer to DAAL entity is NULL")
-        res = get_{{flatname}}_{{m[1]}}(self.c_ptr)
 {% if 'NumericTablePtr' in rtype %}
-        return {{'<object>make_nda(res, e2s_algorithms_'+flatname+'_'+m[1]+')' if 'dict_NumericTablePtr' in rtype else '<object>make_nda(res)'}}
+        cdef {{rtype}} * res = get_{{flatname}}_{{m[1]}}(self.c_ptr)
+        res_obj = {{'<object>make_nda(res, e2s_algorithms_'+flatname+'_'+m[1]+')' if 'dict_NumericTablePtr' in rtype else '<object>make_nda(res)'}}
+        del res
+        return res_obj
 {% else %}
+        res = get_{{flatname}}_{{m[1]}}(self.c_ptr)
         return res
 {% endif %}
 {% endif %}


### PR DESCRIPTION
@fschlimb @Alexander-Makaryev 

When generating property, like transformedData property
of pca_transform_result, we call

   get_pca_transform_result_transformedData

which returns
   new daal::services::SharedPtr< T >(
       resultPtr->get(daal::algorithms::pca::transform::transformedData) );

resultPtr->get(daal::algorithms::pca::transform::transformedData)
returns NumericTablePtr, which is a SharedPtr.

new daal::services::SharedPtr< T > of that creates a new shared pointer
which needs to be deleted, otherwise the numeric table holding the
transformed data will never get freed.

The change specifies type of the variable res holding the result
of get_pca_transform_result_transformedData and adds del res
which translates in C++ into delete res:

   data_management_NumericTablePtr *__pyx_t_3;
    __pyx_t_3 = get_pca_transform_result_transformedData(__pyx_v_self->c_ptr);
    __pyx_v_res = __pyx_t_3;
    __pyx_t_4 = make_nda(__pyx_v_res);
    delete __pyx_t_3;

This however does not yet fix the #92 in its entirety.