### PR TITLE
Try conda forge circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
             . ~/miniconda/etc/profile.d/conda.sh
             conda activate bld
             mkdir -p /tmp/out
-            conda build --python=36 --override-channels -c intel -c conda-forge --output-folder /tmp/out --no-test conda-recipe
+            conda build --python=36 --override-channels -c conda-forge -c defaults --output-folder /tmp/out --no-test conda-recipe
       - run:
           name: Testing sklearn patches
           command: |

--- a/.circleci/setup_env.sh
+++ b/.circleci/setup_env.sh
@@ -7,10 +7,8 @@ conda config --set always_yes yes --set changeps1 no
 conda update -q conda
 conda install -q conda-build
 conda create -n bld --override-channels -c intel daal daal-devel tbb
-conda install -q -n bld --override-channels -c defaults python=3.6 numpy scipy pytest pandas pyyaml joblib
-conda install -q -n bld -c defaults --override-channels --no-deps libgcc-ng libstdcxx-ng
-conda install -q -n bld -c conda-forge --override-channels numpydocs
-conda install -q -n bld -c conda-forge --override-channels --no-deps mpi libgfortran mpich
+conda install -q -n bld --override-channels -c defaults python=3.6 numpy scipy pytest pandas pyyaml joblib numpydoc
+conda install -q -n bld -c conda-forge --override-channels mpi mpich
 gcc -v
 g++ -v
 head /proc/cpuinfo

--- a/.circleci/setup_env.sh
+++ b/.circleci/setup_env.sh
@@ -6,10 +6,11 @@ hash -r
 conda config --set always_yes yes --set changeps1 no
 conda update -q conda
 conda install -q conda-build
-conda create -q -n bld --override-channels -c intel -c conda-forge python=3.6 numpy scipy pytest daal tbb pandas numpydoc
+conda create -n bld --override-channels -c intel daal daal-devel tbb
+conda install -q -n bld --override-channels -c defaults python=3.6 numpy scipy pytest pandas pyyaml joblib
 conda install -q -n bld -c defaults --override-channels --no-deps libgcc-ng libstdcxx-ng
+conda install -q -n bld -c conda-forge --override-channels numpydocs
 conda install -q -n bld -c conda-forge --override-channels --no-deps mpi libgfortran mpich
-conda install -q -n bld -c defaults pyyaml joblib
 gcc -v
 g++ -v
 head /proc/cpuinfo


### PR DESCRIPTION
Changed `set_up_env.sh` and used default channel alongside conda-forge for conda-build.

The 13-15 test failures we saw in test suite of unpatched scikit-learn, see #93, are gone.

There is a single test failure `test_omp_cv`, which I suspect is just flaky. Need to discuss this with @ogrisel or @jeremiedbb.

The patched run also fails ``sklearn/tests/test_pipeline.py::test_pipeline_memory``, with DAAL optimized SVM using more than expected.

@fschlimb @Alexander-Makaryev 