### PR TITLE
Consolidate all sklearn related documentation at a single URL

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -149,27 +149,12 @@ e.g. standard types (integer, float, Numpy arrays, Pandas DataFrames,
 ...). Additionally, if you provide the name of a csv-file as an input argument
 daal4py will work on the entire file content.
 
-Scikit-Learn patches
---------------------
-daal4py can dynamically patch :ref:`certain scikit-learn algorithms <sklearn>` to
-use Intel® DAAL as the underlying solver, while getting the same solution faster.
-To unlock performance for your application, simply run::
+Scikit-Learn API and patching
+-----------------------------
+daal4py exposes some DAAL solvers using a scikit-learn compatible API.
 
-    python -m daal4py my_application.py
+daal4py can furthermore monkey-patch the ``sklearn`` package to use the DAAL
+solvers as drop-in replacement without any code change.
 
-Patches can also be enabled programmatically::
-
-    import daal4py.sklearn
-    daal4py.sklearn.patch_sklearn()
-
-Additionally, daal4py.sklearn contains scikit-learn API compatible :ref:`classes <sklearn>`
-which implement a subset of scikit-learn algorithms using Intel® DAAL. These classes are
-always available, whether the scikit-learn itself has been patched, or not. For example::
-
-     import sklearn, sklearn.datasets, sklearn.svm, sklearn.metrics
-     digits = sklearn.datasets.load_digits()
-     import daal4py.sklearn
-     clf_d = daal4py.sklearn.svm.SVC(kernel='rbf', gamma='scale', C = 0.5).fit(X, y)
-     clf_v = sklearn.svm.SVC(kernel='rbf', gamma='scale', C =0.5).fit(X, y)
-     sklearn.metrics.v_measure_score(y, clf_v.predict(X)) # output: 0.977068068172132
-     sklearn.metrics.v_measure_score(y, clf_d.predict(X)) # output: 0.977068068172132
+Please refer to the section on :ref:`scikit-learn API and patching <sklearn>`
+for more details.

--- a/doc/sklearn.rst
+++ b/doc/sklearn.rst
@@ -60,30 +60,30 @@ scikit-learn API
 The ``daal4py.sklearn`` package contains scikit-learn compatible API which
 implement a subset of scikit-learn algorithms using Intel® DAAL.
 
-Currently, these include::
+Currently, these include:
 
-    1. ``daal4py.sklearn.neighbors.KNeighborsClassifier``
-    2. ``daal4py.sklearn.ensemble.RandomForestClassifier``
-    3. ``daal4py.sklearn.ensemble.RandomForestRegressor``
-    4. ``daal4py.sklearn.cluster.KMeans``
-    5. ``daal4py.sklearn.decomposition.PCA``
-    6. ``daal4py.sklearn.linear_model.Ridge``
-    7. ``daal4py.sklearn.svm.SVC``
-    8. ``daal4py.sklearn.linear_model.logistic_regression_path``
-    9. ``daal4py.sklearn.linear_model.LogisticRegression``
+1. ``daal4py.sklearn.neighbors.KNeighborsClassifier``
+2. ``daal4py.sklearn.ensemble.RandomForestClassifier``
+3. ``daal4py.sklearn.ensemble.RandomForestRegressor``
+4. ``daal4py.sklearn.cluster.KMeans``
+5. ``daal4py.sklearn.decomposition.PCA``
+6. ``daal4py.sklearn.linear_model.Ridge``
+7. ``daal4py.sklearn.svm.SVC``
+8. ``daal4py.sklearn.linear_model.logistic_regression_path``
+9. ``daal4py.sklearn.linear_model.LogisticRegression``
 
- These classes are always available, whether the scikit-learn itself has been
- patched, or not. For example::
+These classes are always available, whether the scikit-learn itself has been
+patched, or not. For example::
 
-     import daal4py.sklearn
-     daal4py.sklearn.unpatch_sklearn()
-     import sklearn.datasets, sklearn.svm
+    import daal4py.sklearn
+    daal4py.sklearn.unpatch_sklearn()
+    import sklearn.datasets, sklearn.svm
 
-     digits = sklearn.datasets.load_digits()
-     X, y = digits.data, digits.target
+    digits = sklearn.datasets.load_digits()
+    X, y = digits.data, digits.target
 
-     clf_d = daal4py.sklearn.svm.SVC(kernel='rbf', gamma='scale', C = 0.5).fit(X, y)
-     clf_v = sklearn.svm.SVC(kernel='rbf', gamma='scale', C =0.5).fit(X, y)
+    clf_d = daal4py.sklearn.svm.SVC(kernel='rbf', gamma='scale', C = 0.5).fit(X, y)
+    clf_v = sklearn.svm.SVC(kernel='rbf', gamma='scale', C =0.5).fit(X, y)
 
-     clf_d.score(X, y) # output: 0.9905397885364496
-     clf_v.score(X, y) # output: 0.9905397885364496
+    clf_d.score(X, y) # output: 0.9905397885364496
+    clf_v.score(X, y) # output: 0.9905397885364496

--- a/doc/sklearn.rst
+++ b/doc/sklearn.rst
@@ -1,29 +1,38 @@
 .. _sklearn:
 
-################
-Scikit-Learn API
-################
+#############################
+Scikit-Learn API and patching
+#############################
 
-Python interface to efficient Intel® Data Analytics and Acceleration Library (DAAL)
-provided by daal4py allows one to create scikit-learn compatible estimators,
-transformers, clusterers, etc. powered by DAAL which are nearly as efficient as
-native programs.
+Python interface to efficient Intel® Data Analytics and Acceleration Library
+(DAAL) provided by daal4py allows one to create scikit-learn compatible
+estimators, transformers, clusterers, etc. powered by DAAL which are nearly as
+efficient as native programs.
 
-Submodule `daal4py.sklearn` provides such classes.
+.. _sklearn_patches:
 
-Currently, these include::
+DAAL accelerated scikit-learn
+------------------------------
 
-    1. daal4py.sklearn.neighbors.KNeighborsClassifier
-    2. daal4py.sklearn.ensemble.RandomForestClassifier
-    3. daal4py.sklearn.ensemble.RandomForestRegressor
-    4. daal4py.sklearn.cluster.KMeans
-    5. daal4py.sklearn.decomposition.PCA
-    6. daal4py.sklearn.linear_model.Ridge
-    7. daal4py.sklearn.svm.SVC
-    8. daal4py.sklearn.linear_model.logistic_regression_path 
-    9. daal4py.sklearn.linear_model.LogisticRegression 
+daal4py can dynamically patch scikit-learn estimators to use Intel® DAAL as the
+underlying solver, while getting the same solution faster.
 
-Additionally, daal4py contains code to monkey-patch the following existing scikit-learn algorithms:
+It is possible to enable those patches without editing the code of a
+scikit-learn application by using the following commandline flag::
+
+    python -m daal4py my_application.py
+
+Patches can also be enabled programmatically::
+
+    import daal4py.sklearn
+    daal4py.sklearn.patch_sklearn()
+
+It is possible to undo the patch with:
+
+    daal4py.sklearn.unpatch_sklearn()
+
+Applying the monkey patch will impact the following existing scikit-learn
+algorithms:
 
 1. `sklearn.linear_model.LinearRegression <https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.LinearRegression.html>`__
 2. `sklearn.linear_model.Ridge <https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.Ridge.html>`__ (solver='auto')
@@ -33,6 +42,48 @@ Additionally, daal4py contains code to monkey-patch the following existing sciki
 6. `sklearn.metric.pairwise_distance <https://scikit-learn.org/stable/modules/generated/sklearn.metrics.pairwise_distances.html>`__, with metric='cosine' or metric='correlation'
 7. `sklearn.svm.SVC <https://scikit-learn.org/stable/modules/generated/sklearn.svm.SVC.html>`__
 
-Monkey-patched scikit-learn passes scikit-learn's own test suite, with few exceptions, specified in `deselected_tests.yaml <https://github.com/IntelPython/daal4py/blob/master/deselected_tests.yaml>`__.
-       
-Scikit-learn's test suite executes `check_estimator <https://scikit-learn.org/stable/modules/generated/sklearn.utils.estimator_checks.check_estimator.html>`__ on all added and monkey-patched classes, which are discovered by means of introspection. This assures scikit-learn API compatibility of `daal4py.sklearn` classes.
+Monkey-patched scikit-learn clases and functions passes scikit-learn's own test
+suite, with few exceptions, specified in `deselected_tests.yaml
+<https://github.com/IntelPython/daal4py/blob/master/deselected_tests.yaml>`__.
+
+In particular the tests execute `check_estimator
+<https://scikit-learn.org/stable/modules/generated/sklearn.utils.estimator_checks.check_estimator.html>`__
+on all added and monkey-patched classes, which are discovered by means of
+introspection. This assures scikit-learn API compatibility of all
+`daal4py.sklearn` classes.
+
+.. _sklearn_api:
+
+scikit-learn API
+----------------
+
+The ``daal4py.sklearn`` package contains scikit-learn compatible API which
+implement a subset of scikit-learn algorithms using Intel® DAAL.
+
+Currently, these include::
+
+    1. ``daal4py.sklearn.neighbors.KNeighborsClassifier``
+    2. ``daal4py.sklearn.ensemble.RandomForestClassifier``
+    3. ``daal4py.sklearn.ensemble.RandomForestRegressor``
+    4. ``daal4py.sklearn.cluster.KMeans``
+    5. ``daal4py.sklearn.decomposition.PCA``
+    6. ``daal4py.sklearn.linear_model.Ridge``
+    7. ``daal4py.sklearn.svm.SVC``
+    8. ``daal4py.sklearn.linear_model.logistic_regression_path``
+    9. ``daal4py.sklearn.linear_model.LogisticRegression``
+
+ These classes are always available, whether the scikit-learn itself has been
+ patched, or not. For example::
+
+     import daal4py.sklearn
+     daal4py.sklearn.unpatch_sklearn()
+     import sklearn.datasets, sklearn.svm
+
+     digits = sklearn.datasets.load_digits()
+     X, y = digits.data, digits.target
+
+     clf_d = daal4py.sklearn.svm.SVC(kernel='rbf', gamma='scale', C = 0.5).fit(X, y)
+     clf_v = sklearn.svm.SVC(kernel='rbf', gamma='scale', C =0.5).fit(X, y)
+
+     clf_d.score(X, y) # output: 0.9905397885364496
+     clf_v.score(X, y) # output: 0.9905397885364496


### PR DESCRIPTION
Here is a proposal to gather all the relevant information about scikit-learn integration on a single page that can be referenced from a single URL.

Otherwise it's hard to discover the patching instruction and API usage code snippet that were on the home page from within the sklearn.html page.