### PR TITLE
Make sklearn patching verbose by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ install:
   - hash -r
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
-  - conda install -q conda-build=3.16
+  - conda install -q conda-build
   # Useful for debugging any issues with conda
   - conda info -a
   - gcc -v

--- a/daal4py/sklearn/monkeypatch/dispatcher.py
+++ b/daal4py/sklearn/monkeypatch/dispatcher.py
@@ -99,7 +99,7 @@ def enable(name=None, verbose=True):
         for key in _mapping:
             do_patch(key)
     if verbose and sys.stderr is not None:
-        sys.stderr.write("Intel DAAL solvers for sklearn enabled: "
+        sys.stderr.write("Intel(R) DAAL solvers for sklearn enabled: "
                          "https://intelpython.github.io/daal4py/sklearn.html\n")
 
 

--- a/daal4py/sklearn/monkeypatch/dispatcher.py
+++ b/daal4py/sklearn/monkeypatch/dispatcher.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 #******************************************************************************/
 
+import sys
 import warnings
 from sklearn import __version__ as sklearn_version
 from distutils.version import LooseVersion
@@ -81,7 +82,7 @@ def do_unpatch(name):
         raise ValueError("Has no patch for: " + name)
 
 
-def enable(name=None):
+def enable(name=None, verbose=True):
     if LooseVersion(sklearn_version) < LooseVersion("0.20.0"):
         raise NotImplementedError("daal4py patches apply  for scikit-learn >= 0.20.0 only ...")
     elif LooseVersion(sklearn_version) > LooseVersion("0.21.2"):
@@ -97,6 +98,9 @@ def enable(name=None):
     else:
         for key in _mapping:
             do_patch(key)
+    if verbose and sys.stderr is not None:
+        sys.stderr.write("Intel DAAL solvers for sklearn enabled: "
+                         "https://intelpython.github.io/daal4py/sklearn.html\n")
 
 
 def disable(name=None):


### PR DESCRIPTION
I think it's important to let the user know when sklearn is patched or not.

I think patching could be made silent if some environment variable is explicitly defined but by default otherwise users might be surprised that they are using a class from daal4py while they are expecting only code from the sklearn package.