### PR TITLE
fix/missing of errors in CI

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -46,7 +46,7 @@ test:
         - mpirun -n 4 python -m unittest discover -v -s tests -p spmd*.py # [not win]
         - mpiexec -localonly -n 4 python -m unittest discover -v -s tests -p spmd*.py # [win]
         - python -m unittest discover -v -s tests -p test*.py
-        - cd examples && python run_examples.py && cd ..
+        - cd examples && python run_examples.py
 
 about:
     home: https://intelpython.github.io/daal4py/

--- a/examples/run_examples.py
+++ b/examples/run_examples.py
@@ -47,7 +47,7 @@ req_version['logitboost_batch.py'] = (2020,1)
 req_version['stump_classification_batch.py'] = (2020,1)
 req_version['stump_regression_batch.py'] = (2020,1)
 req_version['saga_batch.py'] = (2019,3)
-#req_version['lasso_regression_batch.py'] = (2020,0)
+req_version['lasso_regression_batch.py'] = (2020,0)
 
 def get_exe_cmd(ex, nodist, nostream):
     if req_version[os.path.basename(ex)] > daal_version:

--- a/examples/run_examples.py
+++ b/examples/run_examples.py
@@ -47,7 +47,7 @@ req_version['logitboost_batch.py'] = (2020,1)
 req_version['stump_classification_batch.py'] = (2020,1)
 req_version['stump_regression_batch.py'] = (2020,1)
 req_version['saga_batch.py'] = (2019,3)
-req_version['lasso_regression_batch.py'] = (2020,0)
+#req_version['lasso_regression_batch.py'] = (2020,0)
 
 def get_exe_cmd(ex, nodist, nostream):
     if req_version[os.path.basename(ex)] > daal_version:


### PR DESCRIPTION
Errors are missed because "cd" command has own exit code that hides exit code from run_examples.py. (look at changes) The first commit is reproducer, in this purpose was removed required version for lasso regression.