### PR TITLE
Sklearn 0.21.3 update

### DIFF
--- a/daal4py/sklearn/monkeypatch/dispatcher.py
+++ b/daal4py/sklearn/monkeypatch/dispatcher.py
@@ -99,7 +99,7 @@ def enable(name=None, verbose=True):
         for key in _mapping:
             do_patch(key)
     if verbose and sys.stderr is not None:
-        sys.stderr.write("Intel(R) DAAL solvers for sklearn enabled: "
+        sys.stderr.write("Intel(R) Data Analytics Acceleration Library (Intel DAAL) solvers for sklearn enabled: "
                          "https://intelpython.github.io/daal4py/sklearn.html\n")
 
 

--- a/daal4py/sklearn/monkeypatch/dispatcher.py
+++ b/daal4py/sklearn/monkeypatch/dispatcher.py
@@ -99,7 +99,7 @@ def enable(name=None, verbose=True):
         for key in _mapping:
             do_patch(key)
     if verbose and sys.stderr is not None:
-        sys.stderr.write("Intel(R) Data Analytics Acceleration Library (Intel DAAL) solvers for sklearn enabled: "
+        sys.stderr.write("Intel(R) Data Analytics Acceleration Library (Intel(R) DAAL) solvers for sklearn enabled: "
                          "https://intelpython.github.io/daal4py/sklearn.html\n")
 
 

--- a/daal4py/sklearn/monkeypatch/dispatcher.py
+++ b/daal4py/sklearn/monkeypatch/dispatcher.py
@@ -85,9 +85,9 @@ def do_unpatch(name):
 def enable(name=None, verbose=True):
     if LooseVersion(sklearn_version) < LooseVersion("0.20.0"):
         raise NotImplementedError("daal4py patches apply  for scikit-learn >= 0.20.0 only ...")
-    elif LooseVersion(sklearn_version) > LooseVersion("0.21.2"):
+    elif LooseVersion(sklearn_version) > LooseVersion("0.21.3"):
         warn_msg = ("daal4py {daal4py_version} has only been tested " +
-                    "with scikit-learn 0.21.2, found version: {sklearn_version}")
+                    "with scikit-learn 0.21.3, found version: {sklearn_version}")
         warnings.warn(warn_msg.format(
             daal4py_version=daal4py_version,
             sklearn_version=sklearn_version)

--- a/deselected_tests.yaml
+++ b/deselected_tests.yaml
@@ -12,15 +12,15 @@ deselected_tests:
 
   # Deselecting 5 SVC related tests where duplicate samples end up being support vectors
   # See: https://github.com/scikit-learn/scikit-learn/issues/12738
-  - svm/tests/test_svm.py::test_sample_weights
-  - svm/tests/test_svm.py::test_precomputed
-  - svm/tests/test_sparse.py::test_sparse
-  - svm/tests/test_sparse.py::test_svc_iris
-  - ensemble/tests/test_bagging.py::test_sparse_classification
+  - svm/tests/test_svm.py::test_sample_weights <0.21.3
+  - svm/tests/test_svm.py::test_precomputed    <0.21.3
+  - svm/tests/test_sparse.py::test_sparse      <0.21.3
+  - svm/tests/test_sparse.py::test_svc_iris    <0.21.3
+  - ensemble/tests/test_bagging.py::test_sparse_classification <0.21.3
 
   # test_k_means_fit_predict is known to sporadically fail for float32 inputs in multithreaded runs
   # See: https://github.com/IntelPython/daal4py/issues/25
-  - cluster/tests/test_k_means.py::test_k_means_fit_predict
+  - cluster/tests/test_k_means.py::test_k_means_fit_predict <0.21.3
 
   # test_non_uniform_strategies fails due to differences in handling of vacuous clusters after update
   # See https://github.com/IntelPython/daal4py/issues/69

--- a/deselected_tests.yaml
+++ b/deselected_tests.yaml
@@ -20,7 +20,7 @@ deselected_tests:
 
   # test_k_means_fit_predict is known to sporadically fail for float32 inputs in multithreaded runs
   # See: https://github.com/IntelPython/daal4py/issues/25
-  - cluster/tests/test_k_means.py::test_k_means_fit_predict <0.21.3
+  - cluster/tests/test_k_means.py::test_k_means_fit_predict
 
   # test_non_uniform_strategies fails due to differences in handling of vacuous clusters after update
   # See https://github.com/IntelPython/daal4py/issues/69


### PR DESCRIPTION
@Alexander-Makaryev @fschlimb 

Updated dispatcher to be compatible with sklearn==0.21.3, also removed SVM test failures from deselected.yaml

Updated message printed to stderr when patches are activated to use full product name, rather than the abbreviation