### PR TITLE
Support MPI_LIBNAME env.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,10 @@ else:
     DIST_CPPS    = ['src/transceiver.cpp']
     MPI_INCDIRS = [jp(mpi_root, 'include')]
     MPI_LIBDIRS = [jp(mpi_root, 'lib')]
-    if IS_WIN:
+    MPI_LIBNAME = getattr(os.environ, 'MPI_LIBNAME', None)
+    if MPI_LIBNAME:
+        MPI_LIBS = [MPI_LIBNAME]
+    elif IS_WIN:
         if os.path.isfile(jp(mpi_root, 'lib', 'mpi.lib')):
             MPI_LIBS    = ['mpi']
         if os.path.isfile(jp(mpi_root, 'lib', 'impi.lib')):


### PR DESCRIPTION
When compiling daal4py with Cray MPI, the library name is not 'mpi',
so an edit to setup.py is needed to compile DAAL4PY.

Now one can just set MPI_LIBNAME to the intended library name.
If the MPI shared library is `libmpi_gnu44.so`, we set `MPI_LIBNAME=mpi_gnu44`

@Alexander-Makaryev @fschlimb 