### PR TITLE
Use DAAL in SVC only if break_ties=False

### DIFF
--- a/daal4py/sklearn/svm/svm.py
+++ b/daal4py/sklearn/svm/svm.py
@@ -426,7 +426,7 @@ def fit(self, X, y, sample_weight=None):
         # see comment on the other call to np.iinfo in this file
         seed = rnd.randint(np.iinfo('i').max)
 
-        if ( not sparse and not self.probability and getattr(self, 'break_ties', False) and
+        if ( not sparse and not self.probability and not getattr(self, 'break_ties', False) and
              sample_weight.size == 0 and self.class_weight is None and kernel in ['linear', 'rbf']):
 
             self._daal_fit = True

--- a/deselected_tests.yaml
+++ b/deselected_tests.yaml
@@ -12,11 +12,11 @@ deselected_tests:
 
   # Deselecting 5 SVC related tests where duplicate samples end up being support vectors
   # See: https://github.com/scikit-learn/scikit-learn/issues/12738
-  - svm/tests/test_svm.py::test_sample_weights <0.21.3
-  - svm/tests/test_svm.py::test_precomputed    <0.21.3
-  - svm/tests/test_sparse.py::test_sparse      <0.21.3
-  - svm/tests/test_sparse.py::test_svc_iris    <0.21.3
-  - ensemble/tests/test_bagging.py::test_sparse_classification <0.21.3
+  - svm/tests/test_svm.py::test_sample_weights
+  - svm/tests/test_svm.py::test_precomputed
+  - svm/tests/test_sparse.py::test_sparse
+  - svm/tests/test_sparse.py::test_svc_iris
+  - ensemble/tests/test_bagging.py::test_sparse_classification
 
   # test_k_means_fit_predict is known to sporadically fail for float32 inputs in multithreaded runs
   # See: https://github.com/IntelPython/daal4py/issues/25


### PR DESCRIPTION
Running `sklearn.svm.SVC.fit()` with daal4py 2019.5 with scikit-learn 0.21.x was not using DAAL acceleration. We were checking that `getattr(self, 'break_ties', False)` is `True`, but the wrapper for `predict` was checking the opposite, so neither fit nor predict were running with DAAL backend.