### PR TITLE
BUG: mpi_transciever_impl should be always initialized

### DIFF
--- a/src/mpi/mpi_transceiver.cpp
+++ b/src/mpi/mpi_transceiver.cpp
@@ -20,13 +20,13 @@
 
 void mpi_transceiver::init()
 {
-    int is_initialized;
-    MPI_Initialized(&is_initialized);
+    int is_mpi_initialized = 0;
+    MPI_Initialized(&is_mpi_initialized);
     // protect against double-init
-    if(!is_initialized) {
+    if(!is_mpi_initialized) {
         MPI_Init(NULL, NULL);
-        transceiver_impl::init();
     }
+    transceiver_impl::init();	
 }
 
 void mpi_transceiver::fini()

--- a/src/transceiver.h
+++ b/src/transceiver.h
@@ -153,16 +153,20 @@ class transceiver_impl : public transceiver_iface
 public:
     transceiver_impl()
         : m_me(-1),
-          m_nMembers(0)
+	  m_nMembers(0),
+	  m_initialized(false)
     {}
 
     // implementations/derived classes must call this in their init()
     virtual void init()
     {
-        m_me = me();
-        m_nMembers = nMembers();
+	if (!m_initialized) {
+	    m_me = me();
+	    m_nMembers = nMembers();
+	    m_initialized = true;
+	}
     }
-
+    
     virtual void * gather(const void * ptr, size_t N, size_t root, const size_t * sizes, bool varying)
     {
         throw std::logic_error("transceiver_base::gather not yet implemented");
@@ -183,6 +187,7 @@ public:
         throw std::logic_error("transceiver_base::reduce_exscan not yet implemented");
     }
 protected:
+    bool m_initialized;
     size_t m_me;        // result of me()
     size_t m_nMembers;  // result of nMembers()
 };


### PR DESCRIPTION
@Alexander-Makaryev @fschlimb 

In the scenario where `import mpi4py` was executed prior to a
call to daal4py.daalinit(), and MPI has already been initialized
the mpi_transciever_impl internal state was not being initialized
causing a crash in the following example:

```
import numpy as np
from mpi4py import MPI
import os, os.path
import daal4py as d4p

d4p.daalinit()

fn = os.path.join('data', 'X_' + str( d4p.my_procid() ) + '.csv')
X = np.loadtxt(fn)
assert X.size > 0

svd_distr = d4p.svd(
    fptype='double',
    distributed=True,
    )
 res = svd_distr.compute(X)

d4p.daalfini()
``