### PR TITLE
Adjust to deperecation changes of check_is_fitted

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.0
 jobs:
   build_pypi:
     docker:
-      - image: circleci/python:3.6.7
+      - image: circleci/python:3.7.5
 
     working_directory: ~/daal4py-ci
 
@@ -20,7 +20,7 @@ jobs:
             . ~/miniconda/etc/profile.d/conda.sh
             conda activate bld
             mkdir -p /tmp/out
-            conda build --python=36 --override-channels -c conda-forge -c defaults --output-folder /tmp/out --no-test conda-recipe
+            conda build --python=37 --override-channels -c conda-forge -c defaults --output-folder /tmp/out --no-test conda-recipe
       - run:
           name: Testing sklearn patches
           command: |
@@ -28,7 +28,7 @@ jobs:
             . ~/miniconda/etc/profile.d/conda.sh
             conda activate bld
             # work around bug in scikit-learn
-            conda install -y -c intel --override-channels cython
+            conda install -y -c conda-forge --override-channels cython
             conda install -q /tmp/out/*/daal4py-*.tar.bz2
             pip install -q scikit-learn
             conda list
@@ -39,7 +39,7 @@ jobs:
 
   build_master:
     docker:
-      - image: circleci/python:3.6.7
+      - image: circleci/python:3.7.5
 
     working_directory: ~/daal4py-ci
 
@@ -62,7 +62,7 @@ jobs:
             . ~/miniconda/etc/profile.d/conda.sh
             conda activate bld
             mkdir -p /tmp/out
-            conda build --python=36 --override-channels -c intel -c conda-forge --output-folder /tmp/out --no-test conda-recipe
+            conda build --python=37 --override-channels -c intel -c conda-forge --output-folder /tmp/out --no-test conda-recipe
       - run:
           name: Testing sklearn patches
           command: |

--- a/.circleci/setup_env.sh
+++ b/.circleci/setup_env.sh
@@ -7,7 +7,7 @@ conda config --set always_yes yes --set changeps1 no
 conda update -q conda
 conda install -q conda-build
 conda create -n bld --override-channels -c intel daal daal-devel tbb
-conda install -q -n bld --override-channels -c defaults python=3.6 numpy scipy pytest pandas pyyaml joblib numpydoc
+conda install -q -n bld --override-channels -c defaults python=3.7 numpy scipy pytest pandas pyyaml joblib numpydoc
 conda install -q -n bld -c conda-forge --override-channels mpi mpich
 gcc -v
 g++ -v

--- a/daal4py/sklearn/cluster/__init__.py
+++ b/daal4py/sklearn/cluster/__init__.py
@@ -1,4 +1,8 @@
 from .k_means import KMeans
-from .dbscan import DBSCAN
+__all__ = ['KMeans']
 
-__all__ = ['KMeans', 'DBSCAN']
+try:
+    from .dbscan import DBSCAN
+    __all__ += ['DBSCAN']
+except ImportError:
+    pass

--- a/daal4py/sklearn/cluster/__init__.py
+++ b/daal4py/sklearn/cluster/__init__.py
@@ -1,3 +1,4 @@
 from .k_means import KMeans
+from .dbscan import DBSCAN
 
-__all__ = ['KMeans']
+__all__ = ['KMeans', 'DBSCAN']

--- a/daal4py/sklearn/cluster/_dbscan_0_21.py
+++ b/daal4py/sklearn/cluster/_dbscan_0_21.py
@@ -1,0 +1,249 @@
+#
+#*******************************************************************************
+# Copyright 2014-2020 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#******************************************************************************/
+
+import numpy as np
+import warnings
+from scipy import sparse
+
+from sklearn.utils import (check_array, check_consistent_length)
+
+from sklearn.cluster import DBSCAN as DBSCAN_original
+
+import daal4py
+from daal4py.sklearn.utils import (make2d, getFPType)
+
+
+def _daal_dbscan(X, eps=0.5, min_samples=5, sample_weight=None):
+    if not eps > 0.0:
+        raise ValueError("eps must be positive.")
+
+    X = check_array(X, dtype=[np.float64, np.float32])
+    if sample_weight is not None:
+        sample_weight = np.asarray(sample_weight)
+        check_consistent_length(X, sample_weight)
+        ww = make2d(sample_weight)
+    else:
+        ww = None
+
+    XX = make2d(X)
+
+    fpt = getFPType(XX)
+    alg = daal4py.dbscan(
+        method='defaultDense',
+        epsilon=float(eps),
+        minObservations=int(min_samples),
+        resultsToCompute="computeCoreIndices")
+
+    daal_res = alg.compute(XX, ww)
+    n_clusters = daal_res.nClusters[0, 0]
+    assignments = daal_res.assignments.ravel()
+    if daal_res.coreIndices is not None:
+        core_ind = daal_res.coreIndices.ravel()
+    else:
+        core_ind = np.array([], dtype=np.intc)
+
+    return (core_ind, assignments)
+
+
+class DBSCAN(DBSCAN_original):
+    """Perform DBSCAN clustering from vector array or distance matrix.
+
+    DBSCAN - Density-Based Spatial Clustering of Applications with Noise.
+    Finds core samples of high density and expands clusters from them.
+    Good for data which contains clusters of similar density.
+
+    Read more in the :ref:`User Guide <dbscan>`.
+
+    Parameters
+    ----------
+    eps : float, optional
+        The maximum distance between two samples for one to be considered
+        as in the neighborhood of the other. This is not a maximum bound
+        on the distances of points within a cluster. This is the most
+        important DBSCAN parameter to choose appropriately for your data set
+        and distance function.
+
+    min_samples : int, optional
+        The number of samples (or total weight) in a neighborhood for a point
+        to be considered as a core point. This includes the point itself.
+
+    metric : string, or callable
+        The metric to use when calculating distance between instances in a
+        feature array. If metric is a string or callable, it must be one of
+        the options allowed by :func:`sklearn.metrics.pairwise_distances` for
+        its metric parameter.
+        If metric is "precomputed", X is assumed to be a distance matrix and
+        must be square. X may be a :term:`Glossary <sparse graph>`, in which
+        case only "nonzero" elements may be considered neighbors for DBSCAN.
+
+        .. versionadded:: 0.17
+           metric *precomputed* to accept precomputed sparse matrix.
+
+    metric_params : dict, optional
+        Additional keyword arguments for the metric function.
+
+        .. versionadded:: 0.19
+
+    algorithm : {'auto', 'ball_tree', 'kd_tree', 'brute', 'daal'}, optional
+        The algorithm to be used by the NearestNeighbors module
+        to compute pointwise distances and find nearest neighbors.
+        See NearestNeighbors module documentation for details.
+
+        If algorithm is set to 'daal', Intel(R) DAAL will be used.
+
+    leaf_size : int, optional (default = 30)
+        Leaf size passed to BallTree or cKDTree. This can affect the speed
+        of the construction and query, as well as the memory required
+        to store the tree. The optimal value depends
+        on the nature of the problem.
+
+    p : float, optional
+        The power of the Minkowski metric to be used to calculate distance
+        between points.
+
+    n_jobs : int or None, optional (default=None)
+        The number of parallel jobs to run.
+        ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
+        ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
+        for more details.
+
+    Attributes
+    ----------
+    core_sample_indices_ : array, shape = [n_core_samples]
+        Indices of core samples.
+
+    components_ : array, shape = [n_core_samples, n_features]
+        Copy of each core sample found by training.
+
+    labels_ : array, shape = [n_samples]
+        Cluster labels for each point in the dataset given to fit().
+        Noisy samples are given the label -1.
+
+    Examples
+    --------
+    >>> from sklearn.cluster import DBSCAN
+    >>> import numpy as np
+    >>> X = np.array([[1, 2], [2, 2], [2, 3],
+    ...               [8, 7], [8, 8], [25, 80]])
+    >>> clustering = DBSCAN(eps=3, min_samples=2).fit(X)
+    >>> clustering.labels_
+    array([ 0,  0,  0,  1,  1, -1])
+    >>> clustering
+    DBSCAN(eps=3, min_samples=2)
+
+    See also
+    --------
+    OPTICS
+        A similar clustering at multiple values of eps. Our implementation
+        is optimized for memory usage.
+
+    Notes
+    -----
+    For an example, see :ref:`examples/cluster/plot_dbscan.py
+    <sphx_glr_auto_examples_cluster_plot_dbscan.py>`.
+
+    This implementation bulk-computes all neighborhood queries, which increases
+    the memory complexity to O(n.d) where d is the average number of neighbors,
+    while original DBSCAN had memory complexity O(n). It may attract a higher
+    memory complexity when querying these nearest neighborhoods, depending
+    on the ``algorithm``.
+
+    One way to avoid the query complexity is to pre-compute sparse
+    neighborhoods in chunks using
+    :func:`NearestNeighbors.radius_neighbors_graph
+    <sklearn.neighbors.NearestNeighbors.radius_neighbors_graph>` with
+    ``mode='distance'``, then using ``metric='precomputed'`` here.
+
+    Another way to reduce memory and computation time is to remove
+    (near-)duplicate points and use ``sample_weight`` instead.
+
+    :class:`cluster.OPTICS` provides a similar clustering with lower memory
+    usage.
+
+    References
+    ----------
+    Ester, M., H. P. Kriegel, J. Sander, and X. Xu, "A Density-Based
+    Algorithm for Discovering Clusters in Large Spatial Databases with Noise".
+    In: Proceedings of the 2nd International Conference on Knowledge Discovery
+    and Data Mining, Portland, OR, AAAI Press, pp. 226-231. 1996
+
+    Schubert, E., Sander, J., Ester, M., Kriegel, H. P., & Xu, X. (2017).
+    DBSCAN revisited, revisited: why and how you should (still) use DBSCAN.
+    ACM Transactions on Database Systems (TODS), 42(3), 19.
+    """
+
+    def __init__(self, eps=0.5, min_samples=5, metric='euclidean',
+                 metric_params=None, algorithm='auto', leaf_size=30, p=None,
+                 n_jobs=None):
+        self.eps = eps
+        self.min_samples = min_samples
+        self.metric = metric
+        self.metric_params = metric_params
+        self.algorithm = algorithm
+        self.leaf_size = leaf_size
+        self.p = p
+        self.n_jobs = n_jobs
+
+    def fit(self, X, y=None, sample_weight=None):
+        """Perform DBSCAN clustering from features, or distance matrix.
+
+        Parameters
+        ----------
+        X : array-like or sparse matrix, shape (n_samples, n_features), or \
+            (n_samples, n_samples)
+            Training instances to cluster, or distances between instances if
+            ``metric='precomputed'``. If a sparse matrix is provided, it will
+            be converted into a sparse ``csr_matrix``.
+
+        sample_weight : array, shape (n_samples,), optional
+            Weight of each sample, such that a sample with a weight of at least
+            ``min_samples`` is by itself a core sample; a sample with a
+            negative weight may inhibit its eps-neighbor from being core.
+            Note that weights are absolute, and default to 1.
+
+        y : Ignored
+            Not used, present here for API consistency by convention.
+
+        Returns
+        -------
+        self
+
+        """
+        X = check_array(X, accept_sparse='csr')
+
+        if not self.eps > 0.0:
+            raise ValueError("eps must be positive.")
+
+        if sample_weight is not None:
+            sample_weight = np.asarray(sample_weight)
+            check_consistent_length(X, sample_weight)
+
+        _daal_ready = ((self.algorithm in ['auto', 'brute']) and
+                       (self.metric == 'euclidean' or
+                       (self.metric == 'minkowski' and self.p == 2)) and 
+                       isinstance(X, np.ndarray) and (X.dtype.kind in ['d', 'f']))
+        if _daal_ready:
+            core_ind, assignments = _daal_dbscan(
+                X, self.eps,
+                self.min_samples,
+                sample_weight=sample_weight)
+            self.core_sample_indices_ = core_ind
+            self.labels_ = assignments
+            self.components_ = np.take(X, core_ind, axis=0)
+            return self
+        else:
+            return super().fit(X, y, sample_weight=sample_weight)

--- a/daal4py/sklearn/cluster/_dbscan_0_22.py
+++ b/daal4py/sklearn/cluster/_dbscan_0_22.py
@@ -1,0 +1,248 @@
+#
+#*******************************************************************************
+# Copyright 2014-2020 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#******************************************************************************/
+
+import numpy as np
+import warnings
+from scipy import sparse
+
+from sklearn.utils import check_array
+from sklearn.utils.validation import _check_sample_weight
+
+from sklearn.cluster import DBSCAN as DBSCAN_original
+
+import daal4py
+from daal4py.sklearn.utils import (make2d, getFPType)
+
+
+def _daal_dbscan(X, eps=0.5, min_samples=5, sample_weight=None):
+    if not eps > 0.0:
+        raise ValueError("eps must be positive.")
+
+    X = check_array(X, dtype=[np.float64, np.float32])
+    if sample_weight is not None:
+        sample_weight = _check_sample_weight(sample_weight, X)
+        ww = make2d(sample_weight)
+    else:
+        ww = None
+
+    XX = make2d(X)
+
+    fpt = getFPType(XX)
+    alg = daal4py.dbscan(
+        method='defaultDense',
+        epsilon=float(eps),
+        minObservations=int(min_samples),
+        resultsToCompute="computeCoreIndices")
+
+    daal_res = alg.compute(XX, ww)
+    n_clusters = daal_res.nClusters[0, 0]
+    assignments = daal_res.assignments.ravel()
+    if daal_res.coreIndices is not None:
+        core_ind = daal_res.coreIndices.ravel()
+    else:
+        core_ind = np.array([], dtype=np.intc)
+
+    return (core_ind, assignments)
+
+
+class DBSCAN(DBSCAN_original):
+    """Perform DBSCAN clustering from vector array or distance matrix.
+
+    DBSCAN - Density-Based Spatial Clustering of Applications with Noise.
+    Finds core samples of high density and expands clusters from them.
+    Good for data which contains clusters of similar density.
+
+    Read more in the :ref:`User Guide <dbscan>`.
+
+    Parameters
+    ----------
+    eps : float, optional
+        The maximum distance between two samples for one to be considered
+        as in the neighborhood of the other. This is not a maximum bound
+        on the distances of points within a cluster. This is the most
+        important DBSCAN parameter to choose appropriately for your data set
+        and distance function.
+
+    min_samples : int, optional
+        The number of samples (or total weight) in a neighborhood for a point
+        to be considered as a core point. This includes the point itself.
+
+    metric : string, or callable
+        The metric to use when calculating distance between instances in a
+        feature array. If metric is a string or callable, it must be one of
+        the options allowed by :func:`sklearn.metrics.pairwise_distances` for
+        its metric parameter.
+        If metric is "precomputed", X is assumed to be a distance matrix and
+        must be square. X may be a :term:`Glossary <sparse graph>`, in which
+        case only "nonzero" elements may be considered neighbors for DBSCAN.
+
+        .. versionadded:: 0.17
+           metric *precomputed* to accept precomputed sparse matrix.
+
+    metric_params : dict, optional
+        Additional keyword arguments for the metric function.
+
+        .. versionadded:: 0.19
+
+    algorithm : {'auto', 'ball_tree', 'kd_tree', 'brute', 'daal'}, optional
+        The algorithm to be used by the NearestNeighbors module
+        to compute pointwise distances and find nearest neighbors.
+        See NearestNeighbors module documentation for details.
+
+        If algorithm is set to 'daal', Intel(R) DAAL will be used.
+
+    leaf_size : int, optional (default = 30)
+        Leaf size passed to BallTree or cKDTree. This can affect the speed
+        of the construction and query, as well as the memory required
+        to store the tree. The optimal value depends
+        on the nature of the problem.
+
+    p : float, optional
+        The power of the Minkowski metric to be used to calculate distance
+        between points.
+
+    n_jobs : int or None, optional (default=None)
+        The number of parallel jobs to run.
+        ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
+        ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
+        for more details.
+
+    Attributes
+    ----------
+    core_sample_indices_ : array, shape = [n_core_samples]
+        Indices of core samples.
+
+    components_ : array, shape = [n_core_samples, n_features]
+        Copy of each core sample found by training.
+
+    labels_ : array, shape = [n_samples]
+        Cluster labels for each point in the dataset given to fit().
+        Noisy samples are given the label -1.
+
+    Examples
+    --------
+    >>> from sklearn.cluster import DBSCAN
+    >>> import numpy as np
+    >>> X = np.array([[1, 2], [2, 2], [2, 3],
+    ...               [8, 7], [8, 8], [25, 80]])
+    >>> clustering = DBSCAN(eps=3, min_samples=2).fit(X)
+    >>> clustering.labels_
+    array([ 0,  0,  0,  1,  1, -1])
+    >>> clustering
+    DBSCAN(eps=3, min_samples=2)
+
+    See also
+    --------
+    OPTICS
+        A similar clustering at multiple values of eps. Our implementation
+        is optimized for memory usage.
+
+    Notes
+    -----
+    For an example, see :ref:`examples/cluster/plot_dbscan.py
+    <sphx_glr_auto_examples_cluster_plot_dbscan.py>`.
+
+    This implementation bulk-computes all neighborhood queries, which increases
+    the memory complexity to O(n.d) where d is the average number of neighbors,
+    while original DBSCAN had memory complexity O(n). It may attract a higher
+    memory complexity when querying these nearest neighborhoods, depending
+    on the ``algorithm``.
+
+    One way to avoid the query complexity is to pre-compute sparse
+    neighborhoods in chunks using
+    :func:`NearestNeighbors.radius_neighbors_graph
+    <sklearn.neighbors.NearestNeighbors.radius_neighbors_graph>` with
+    ``mode='distance'``, then using ``metric='precomputed'`` here.
+
+    Another way to reduce memory and computation time is to remove
+    (near-)duplicate points and use ``sample_weight`` instead.
+
+    :class:`cluster.OPTICS` provides a similar clustering with lower memory
+    usage.
+
+    References
+    ----------
+    Ester, M., H. P. Kriegel, J. Sander, and X. Xu, "A Density-Based
+    Algorithm for Discovering Clusters in Large Spatial Databases with Noise".
+    In: Proceedings of the 2nd International Conference on Knowledge Discovery
+    and Data Mining, Portland, OR, AAAI Press, pp. 226-231. 1996
+
+    Schubert, E., Sander, J., Ester, M., Kriegel, H. P., & Xu, X. (2017).
+    DBSCAN revisited, revisited: why and how you should (still) use DBSCAN.
+    ACM Transactions on Database Systems (TODS), 42(3), 19.
+    """
+
+    def __init__(self, eps=0.5, min_samples=5, metric='euclidean',
+                 metric_params=None, algorithm='auto', leaf_size=30, p=None,
+                 n_jobs=None):
+        self.eps = eps
+        self.min_samples = min_samples
+        self.metric = metric
+        self.metric_params = metric_params
+        self.algorithm = algorithm
+        self.leaf_size = leaf_size
+        self.p = p
+        self.n_jobs = n_jobs
+
+    def fit(self, X, y=None, sample_weight=None):
+        """Perform DBSCAN clustering from features, or distance matrix.
+
+        Parameters
+        ----------
+        X : array-like or sparse matrix, shape (n_samples, n_features), or \
+            (n_samples, n_samples)
+            Training instances to cluster, or distances between instances if
+            ``metric='precomputed'``. If a sparse matrix is provided, it will
+            be converted into a sparse ``csr_matrix``.
+
+        sample_weight : array, shape (n_samples,), optional
+            Weight of each sample, such that a sample with a weight of at least
+            ``min_samples`` is by itself a core sample; a sample with a
+            negative weight may inhibit its eps-neighbor from being core.
+            Note that weights are absolute, and default to 1.
+
+        y : Ignored
+            Not used, present here for API consistency by convention.
+
+        Returns
+        -------
+        self
+
+        """
+        X = check_array(X, accept_sparse='csr')
+
+        if not self.eps > 0.0:
+            raise ValueError("eps must be positive.")
+
+        if sample_weight is not None:
+            sample_weight = _check_sample_weight(sample_weight, X)
+
+        _daal_ready = ((self.algorithm in ['auto', 'brute']) and
+                       (self.metric == 'euclidean' or
+                       (self.metric == 'minkowski' and self.p == 2)) and 
+                       isinstance(X, np.ndarray) and (X.dtype.kind in ['d', 'f']))
+        if _daal_ready:
+            core_ind, assignments = _daal_dbscan(
+                X, self.eps,
+                self.min_samples,
+                sample_weight=sample_weight)
+            self.core_sample_indices_ = core_ind
+            self.labels_ = assignments
+            self.components_ = np.take(X, core_ind, axis=0)
+            return self
+        else:
+            return super().fit(X, y, sample_weight=sample_weight)

--- a/daal4py/sklearn/cluster/_k_means_0_22.py
+++ b/daal4py/sklearn/cluster/_k_means_0_22.py
@@ -251,7 +251,7 @@ def predict(self, X, sample_weight=None):
     labels : array, shape [n_samples,]
         Index of the cluster each sample belongs to.
     """
-    check_is_fitted(self, 'cluster_centers_')
+    check_is_fitted(self)
 
     X = self._check_test_data(X)
 

--- a/daal4py/sklearn/cluster/dbscan.py
+++ b/daal4py/sklearn/cluster/dbscan.py
@@ -15,10 +15,12 @@
 # limitations under the License.
 #******************************************************************************/
 
+import daal4py
 from sklearn import __version__ as sklearn_version
 from distutils.version import LooseVersion
 
-if LooseVersion(sklearn_version) >= LooseVersion("0.22"):
-    from ._dbscan_0_22 import *
-else:
-    from ._dbscan_0_21 import *
+if hasattr(daal4py, 'dbscan'):
+    if LooseVersion(sklearn_version) >= LooseVersion("0.22"):
+        from ._dbscan_0_22 import *
+    else:
+        from ._dbscan_0_21 import *

--- a/daal4py/sklearn/cluster/dbscan.py
+++ b/daal4py/sklearn/cluster/dbscan.py
@@ -1,0 +1,24 @@
+#
+#*******************************************************************************
+# Copyright 2014-2019 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#******************************************************************************/
+
+from sklearn import __version__ as sklearn_version
+from distutils.version import LooseVersion
+
+if LooseVersion(sklearn_version) >= LooseVersion("0.22"):
+    from ._dbscan_0_22 import *
+else:
+    from ._dbscan_0_21 import *

--- a/daal4py/sklearn/decomposition/_pca_0_22.py
+++ b/daal4py/sklearn/decomposition/_pca_0_22.py
@@ -228,7 +228,7 @@ class PCA(PCA_original):
 
 
     def _transform_daal4py(self, X, whiten=False, scale_eigenvalues=True, check_X=True):
-        check_is_fitted(self, ['mean_', 'components_'], all_or_any=all)
+        check_is_fitted(self)
 
         X = check_array(X, dtype=[np.float64, np.float32], force_all_finite=check_X)
         fpType = getFPType(X)
@@ -462,7 +462,7 @@ class PCA(PCA_original):
         IncrementalPCA(batch_size=3, copy=True, n_components=2, whiten=False)
         >>> ipca.transform(X) # doctest: +SKIP
         """
-        check_is_fitted(self, ['mean_', 'components_'], all_or_any=all)
+        check_is_fitted(self)
 
         X = check_array(X)
         if self.n_components_ > 0:

--- a/daal4py/sklearn/ensemble/decision_forest.py
+++ b/daal4py/sklearn/ensemble/decision_forest.py
@@ -25,6 +25,7 @@ else:
 import numbers
 import warnings
 
+
 import daal4py
 from ..utils import (make2d, getFPType)
 
@@ -37,6 +38,9 @@ from sklearn.utils.multiclass import check_classification_targets
 from sklearn.utils.validation import (check_is_fitted, check_consistent_length)
 from sklearn.base import clone
 from sklearn.exceptions import DataConversionWarning, NotFittedError
+
+from sklearn import __version__ as sklearn_version
+from distutils.version import LooseVersion
 
 def _to_absolute_max_features(max_features, n_features, is_classification=False):
     if max_features is None:
@@ -259,7 +263,10 @@ class RandomForestClassifier(skl_RandomForestClassifier):
 
 
     def predict(self, X):
-        check_is_fitted(self, 'daal_model_')
+        if LooseVersion(sklearn_version) >= LooseVersion("0.22"):
+            check_is_fitted(self)
+        else:
+            check_is_fitted(self, 'daal_model_')
         return self.daal_predict(X)
 
 

--- a/daal4py/sklearn/ensemble/decision_forest.py
+++ b/daal4py/sklearn/ensemble/decision_forest.py
@@ -270,8 +270,13 @@ class RandomForestClassifier(skl_RandomForestClassifier):
             check_is_fitted(self, 'daal_model_')
         return self.daal_predict(X)
 
+
     def _more_tags(self):
-        return {'multioutput': False}
+        if LooseVersion(sklearn_version) >= LooseVersion("0.22"):
+            return {'multioutput': False}
+        else:
+            return dict()
+
 
 
 class RandomForestRegressor(skl_RandomForestRegressor):
@@ -434,7 +439,10 @@ class RandomForestRegressor(skl_RandomForestRegressor):
 
 
     def daal_predict(self, X):
-        check_is_fitted(self, 'daal_model_')
+        if LooseVersion(sklearn_version) >= LooseVersion("0.22"):
+            check_is_fitted(self)
+        else:
+            check_is_fitted(self, 'daal_model_')
         X = self._validate_X_predict(X)
 
         dfr_alg = daal4py.decision_forest_regression_prediction(fptype='float')
@@ -452,5 +460,9 @@ class RandomForestRegressor(skl_RandomForestRegressor):
     def predict(self, X):
         return self.daal_predict(X)
 
+
     def _more_tags(self):
-        return {'multioutput': False}
+        if LooseVersion(sklearn_version) >= LooseVersion("0.22"):
+            return {'multioutput': False}
+        else:
+            return dict()

--- a/daal4py/sklearn/ensemble/decision_forest.py
+++ b/daal4py/sklearn/ensemble/decision_forest.py
@@ -131,6 +131,7 @@ class RandomForestClassifier(skl_RandomForestClassifier):
         self._check_daal_supported_parameters()
         _supported_dtypes_ = [np.single, np.double]
         X = check_array(X, dtype=_supported_dtypes_)
+        y = np.asarray(y)
         y = np.atleast_1d(y)
 
         if y.ndim == 2 and y.shape[1] == 1:
@@ -269,6 +270,8 @@ class RandomForestClassifier(skl_RandomForestClassifier):
             check_is_fitted(self, 'daal_model_')
         return self.daal_predict(X)
 
+    def _more_tags(self):
+        return {'multioutput': False}
 
 
 class RandomForestRegressor(skl_RandomForestRegressor):
@@ -337,6 +340,7 @@ class RandomForestRegressor(skl_RandomForestRegressor):
         self._check_daal_supported_parameters()
         _supported_dtypes_ = [np.double, np.single]
         X = check_array(X, dtype=_supported_dtypes_)
+        y = np.asarray(y)
         y = np.atleast_1d(y)
 
         if y.ndim == 2 and y.shape[1] == 1:
@@ -447,3 +451,6 @@ class RandomForestRegressor(skl_RandomForestRegressor):
 
     def predict(self, X):
         return self.daal_predict(X)
+
+    def _more_tags(self):
+        return {'multioutput': False}

--- a/daal4py/sklearn/linear_model/_linear_0_21.py
+++ b/daal4py/sklearn/linear_model/_linear_0_21.py
@@ -46,13 +46,15 @@ def _daal4py_fit(self, X, y_):
         lr_res = lr_algorithm.compute(X, y)
     except RuntimeError:
         # Normal system is not invertible, try QR
-        lr_algorithm = daal4py.linear_regression_training(
-            fptype=X_fptype,
-            interceptFlag=bool(self.fit_intercept),
-            method='qrDense'
-        )
-        lr_res = lr_algorithm.compute(X, y)
-        
+        try:
+            lr_algorithm = daal4py.linear_regression_training(
+                fptype=X_fptype,
+                interceptFlag=bool(self.fit_intercept),
+                method='qrDense'
+            )
+            lr_res = lr_algorithm.compute(X, y)
+        except RuntimeError:
+            return None
 
     lr_model = lr_res.model
     self.daal_model_ = lr_model
@@ -120,8 +122,9 @@ def fit(self, X, y, sample_weight=None):
             not sp.issparse(X) and
             (X.dtype == np.float64 or X.dtype == np.float32) and
             sample_weight is None):
-        _daal4py_fit(self, X, y)
-        return self
+        res = _daal4py_fit(self, X, y)
+        if res is not None:
+            return res
 
     if sample_weight is not None and np.atleast_1d(sample_weight).ndim > 1:
         raise ValueError("Sample weights must be 1D array or scalar")

--- a/daal4py/sklearn/linear_model/_linear_0_22.py
+++ b/daal4py/sklearn/linear_model/_linear_0_22.py
@@ -23,7 +23,7 @@ from sklearn.utils import check_array, check_X_y, deprecated, as_float_array
 from sklearn.linear_model._base import _rescale_data
 
 from sklearn.utils.fixes import sparse_lsqr
-from sklearn.utils.validation import _check_sample_weight, check_is_fitted
+from sklearn.utils.validation import _check_sample_weight
 
 from sklearn.linear_model import LinearRegression as LinearRegression_original
 

--- a/daal4py/sklearn/monkeypatch/dispatcher.py
+++ b/daal4py/sklearn/monkeypatch/dispatcher.py
@@ -50,7 +50,6 @@ from ..decomposition.pca import PCA as PCA_daal4py
 from ..linear_model.ridge import Ridge as Ridge_daal4py
 from ..linear_model.linear import LinearRegression as LinearRegression_daal4py
 from ..cluster.k_means import KMeans as KMeans_daal4py
-from ..cluster.dbscan import DBSCAN as DBSCAN_daal4py
 from ..svm.svm import SVC as SVC_daal4py
 
 from daal4py import __version__ as daal4py_version
@@ -64,10 +63,16 @@ _mapping = {
     'ridge':     [[(linear_model_module, 'Ridge', Ridge_daal4py), None]],
     'svm':       [[(svm_module, 'SVC', SVC_daal4py), None]],
     'logistic':  [[(logistic_module, _patched_log_reg_path_func_name, daal_optimized_logistic_path), None]],
-    'dbscan':    [[(cluster_module, 'DBSCAN', DBSCAN_daal4py), None]],
 }
 
 del _patched_log_reg_path_func_name
+
+try:
+    from ..cluster.dbscan import DBSCAN as DBSCAN_daal4py
+    _mapping['dbscan'] = [[(cluster_module, 'DBSCAN', DBSCAN_daal4py), None]]
+except ImportError:
+    pass
+
 
 def do_patch(name):
     lname = name.lower()

--- a/daal4py/sklearn/monkeypatch/dispatcher.py
+++ b/daal4py/sklearn/monkeypatch/dispatcher.py
@@ -21,7 +21,7 @@ from sklearn import __version__ as sklearn_version
 from distutils.version import LooseVersion
 import warnings
 
-import sklearn.cluster as kmeans_module
+import sklearn.cluster as cluster_module
 import sklearn.svm as svm_module
 
 if LooseVersion(sklearn_version) >= LooseVersion("0.22"):
@@ -50,6 +50,7 @@ from ..decomposition.pca import PCA as PCA_daal4py
 from ..linear_model.ridge import Ridge as Ridge_daal4py
 from ..linear_model.linear import LinearRegression as LinearRegression_daal4py
 from ..cluster.k_means import KMeans as KMeans_daal4py
+from ..cluster.dbscan import DBSCAN as DBSCAN_daal4py
 from ..svm.svm import SVC as SVC_daal4py
 
 from daal4py import __version__ as daal4py_version
@@ -57,12 +58,13 @@ from daal4py import __version__ as daal4py_version
 
 _mapping = {
     'pca':       [[(decomposition_module, 'PCA', PCA_daal4py), None]],
-    'kmeans':    [[(kmeans_module, 'KMeans', KMeans_daal4py), None]],
+    'kmeans':    [[(cluster_module, 'KMeans', KMeans_daal4py), None]],
     'distances': [[(pairwise, 'pairwise_distances', daal_pairwise_distances), None]],
     'linear':    [[(linear_model_module, 'LinearRegression', LinearRegression_daal4py), None]],
     'ridge':     [[(linear_model_module, 'Ridge', Ridge_daal4py), None]],
     'svm':       [[(svm_module, 'SVC', SVC_daal4py), None]],
     'logistic':  [[(logistic_module, _patched_log_reg_path_func_name, daal_optimized_logistic_path), None]],
+    'dbscan':    [[(cluster_module, 'DBSCAN', DBSCAN_daal4py), None]],
 }
 
 del _patched_log_reg_path_func_name

--- a/daal4py/sklearn/neighbors/kdtree_knn_classifier.py
+++ b/daal4py/sklearn/neighbors/kdtree_knn_classifier.py
@@ -141,7 +141,7 @@ class KNeighborsClassifier(BaseEstimator, ClassifierMixin):
         if LooseVersion(sklearn_version) >= LooseVersion("0.22"):
             check_is_fitted(self)
         else:
-            check_is_fitted(self, ['n_features_', 'n_classes_', 'daal_model_'])
+            check_is_fitted(self, ['n_features_', 'n_classes_'])
 
         # Input validation
         X = check_array(X, dtype=[np.single, np.double])
@@ -151,6 +151,10 @@ class KNeighborsClassifier(BaseEstimator, ClassifierMixin):
         # Trivial case
         if self.n_classes_ == 1:
             return np.full(X.shape[0], self.classes_[0])
+
+        if not hasattr(self, 'daal_model_'):
+            raise ValueError(("The class {} instance does not have 'daal_model_' attribute set. "
+                              "Call 'fit' with appropriate arguments before using this method.").format(type(self).__name__))
 
         # Define type of data
         fptype = getFPType(X)

--- a/daal4py/sklearn/neighbors/kdtree_knn_classifier.py
+++ b/daal4py/sklearn/neighbors/kdtree_knn_classifier.py
@@ -29,6 +29,9 @@ from sklearn.utils import check_random_state
 import daal4py as d4p
 from ..utils import getFPType
 
+from sklearn import __version__ as sklearn_version
+from distutils.version import LooseVersion
+
 
 class KNeighborsClassifier(BaseEstimator, ClassifierMixin):
     def __init__(self,
@@ -135,8 +138,10 @@ class KNeighborsClassifier(BaseEstimator, ClassifierMixin):
 
     def predict(self, X):
         # Check is fit had been called
-        check_is_fitted(self, ['n_features_',
-                               'n_classes_'])
+        if LooseVersion(sklearn_version) >= LooseVersion("0.22"):
+            check_is_fitted(self)
+        else:
+            check_is_fitted(self, ['n_features_', 'n_classes_', 'daal_model_'])
 
         # Input validation
         X = check_array(X, dtype=[np.single, np.double])
@@ -146,8 +151,6 @@ class KNeighborsClassifier(BaseEstimator, ClassifierMixin):
         # Trivial case
         if self.n_classes_ == 1:
             return np.full(X.shape[0], self.classes_[0])
-
-        check_is_fitted(self, ['daal_model_'])
 
         # Define type of data
         fptype = getFPType(X)

--- a/daal4py/sklearn/svm/_svm_0_22.py
+++ b/daal4py/sklearn/svm/_svm_0_22.py
@@ -510,7 +510,7 @@ def predict(self, X):
     -------
     y_pred : array, shape (n_samples,)
     """
-    check_is_fitted(self, 'support_')
+    check_is_fitted(self)
     _break_ties = getattr(self, 'break_ties', False)
     if _break_ties and self.decision_function_shape == 'ovo':
         raise ValueError("break_ties must be False when "

--- a/deselected_tests.yaml
+++ b/deselected_tests.yaml
@@ -36,5 +36,9 @@ deselected_tests:
   # https://github.com/scikit-learn/scikit-learn/pull/15857
   - ensemble/tests/test_stacking.py::test_stacking_cv_influence >=0.22
 
+  # test is unwarranted, but upstream refuses to change it
   # https://github.com/scikit-learn/scikit-learn/pull/15856
   - svm/tests/test_svm.py::test_svm_equivalence_sample_weight_C >=0.22
+
+  # 
+  - tests/test_pipeline.py::test_pipeline_memory 


### PR DESCRIPTION
Previously, test suite generated 4600 warnings, about 3000 more than unpatched run:

Summary of patched run:  = 14087 passed, 147 skipped, 73 deselected, 6 xfailed, 4698 warnings in 4353.74s (1:12:33) =
Summary of unpatched run:  = 13898 passed, 146 skipped, 73 deselected, 6 xfailed, 1590 warnings in 4581.19s (1:16:21) =

Now it is closer to the unpatched one:

=== 14090 passed, 144 skipped, 73 deselected, 6 xfailed, 1598 warnings in 644.34s (0:10:44) ==