### PR TITLE
_make_nt converts FC ndarrays to SOA

### DIFF
--- a/src/daal4py.cpp
+++ b/src/daal4py.cpp
@@ -31,6 +31,7 @@
 #define is_array(a)            ((a) && PyArray_Check(a))
 #define array_type(a)          PyArray_TYPE((PyArrayObject*)a)
 #define array_is_behaved(a)    (PyArray_ISCARRAY_RO((PyArrayObject*)a) && array_type(a)<NPY_OBJECT)
+#define array_is_behaved_F(a)  (PyArray_ISFARRAY_RO((PyArrayObject*)a) && array_type(a)<NPY_OBJECT)
 #define array_is_native(a)     (PyArray_ISNOTSWAPPED((PyArrayObject*)a))
 #define array_numdims(a)       PyArray_NDIM((PyArrayObject*)a)
 #define array_data(a)          PyArray_DATA((PyArrayObject*)a)
@@ -290,7 +291,44 @@ daal::data_management::NumericTablePtr make_nt(PyObject * obj)
                 SET_NPY_FEATURE(PyArray_DESCR(ary)->type, MAKENT_, throw std::invalid_argument("Found unsupported array type"));
 #undef MAKENT_
             } else {
-                ptr = _make_npynt(obj);
+		if(array_is_behaved_F(ary) && (PyArray_NDIM(ary) == 2)) {
+		    int _axes = 0;
+		    npy_intp i = 0;
+		    npy_intp N = PyArray_DIM(ary, 1); // number of columns
+		    npy_intp column_len = PyArray_DIM(ary, 0);
+		    int array_type = PyArray_TYPE(ary);
+		    /*
+		     * Input is 2D F-contiguous array: represent it as SOA numeric table
+		     */
+		    daal::data_management::SOANumericTable * soatbl = NULL;
+
+		    // iterate over columns
+		    PyArrayIterObject * it = (PyArrayIterObject *) PyArray_IterAllButAxis(obj, &_axes);
+		    if (it == NULL) {
+			Py_XDECREF(it);
+			throw std::runtime_error("Creating DAAL SOA table from F-contigous NumPy array failed: iterator could not be created");
+		    }
+
+		    soatbl = new daal::data_management::SOANumericTable(N, column_len);
+		    
+		    while (PyArray_ITER_NOTDONE(it)) {
+			PyArrayObject *slice = (PyArrayObject *) PyArray_SimpleNewFromData(1, &column_len, array_type, (void *)PyArray_ITER_DATA(it));
+			PyArray_SetBaseObject(slice, (PyObject *) ary);
+			Py_INCREF(ary);
+#define SETARRAY_(_T) {daal::services::SharedPtr< _T > _tmp(reinterpret_cast< _T * >(PyArray_ITER_DATA(it)), NumpyDeleter(slice)); soatbl->setArray(_tmp, i);}
+			SET_NPY_FEATURE(PyArray_DESCR(ary)->type, SETARRAY_, throw std::invalid_argument("Found unsupported array type"));
+#undef SETARRAY_
+			PyArray_ITER_NEXT(it);
+			++i;
+		    }
+
+		    if(soatbl->getNumberOfColumns() != N) {
+			delete soatbl;
+			throw std::runtime_error("Creating DAAL SOA table from F-contigous NumPy array failed.");
+		    }
+		    ptr = soatbl;
+		} else
+		    ptr = _make_npynt(obj);
             }
 
             if(!ptr) std::cerr << "Could not convert Python object to DAAL table.\n";
@@ -306,7 +344,7 @@ daal::data_management::NumericTablePtr make_nt(PyObject * obj)
                 for(auto i = 0; i < N; i++) {
                     PyArrayObject * ary = (PyArrayObject*)PyList_GetItem(obj, i);
                     if(PyErr_Occurred()) {PyErr_Print(); throw std::runtime_error("Python Error");}
-                    if(i==0) soatbl = new daal::data_management::SOANumericTable(N, PyArray_DIMS(ary)[0]);
+                    if(i==0) soatbl = new daal::data_management::SOANumericTable(N, PyArray_DIM(ary, 0));
                     if(PyArray_NDIM(ary) != 1) {
                         std::cerr << "Found wrong dimensionality (" << PyArray_NDIM(ary) << ") of array in list when constructing SOA table (must be 1d)";
                         delete soatbl;


### PR DESCRIPTION
@fschlimb @Alexander-Makaryev

Correctness check:

```ipython
(psk022) [15:21:28 fxsatlin03 tmp]$ ipython
Python 3.7.3 | packaged by conda-forge | (default, Dec  6 2019, 08:54:18)
Type 'copyright', 'credits' or 'license' for more information
IPython 7.10.1 -- An enhanced Interactive Python. Type '?' for help.

In [1]: import daal4py, numpy as np, daal4py.sklearn

In [2]: X = np.random.randn(5, 100).T

In [3]: y = np.random.randn(100)

In [4]: daal4py.sklearn.linear_model.Ridge().fit(X, y).coef_
Out[4]: array([-0.0370632 , -0.01074325, -0.10366734,  0.20030913, -0.0705896 ])

In [5]: daal4py.sklearn.linear_model.Ridge().fit(np.ascontiguousarray(X), y).coef_
Out[5]: array([-0.0370632 , -0.01074325, -0.10366734,  0.20030913, -0.0705896 ])

In [6]: quit
```

This closes the performance gap between using pandas DataFrame (underlying f-contiguous layout)
and the actual F-contiguous ndarray input.