### PR TITLE
estimators_ attribues is now a property

### DIFF
--- a/daal4py/sklearn/ensemble/decision_forest.py
+++ b/daal4py/sklearn/ensemble/decision_forest.py
@@ -127,7 +127,7 @@ class RandomForestClassifier(skl_RandomForestClassifier):
                           "setting for min_samples_leaf.")
 
 
-    def daal_fit(self, X, y):
+    def _daal_fit(self, X, y):
         self._check_daal_supported_parameters()
         _supported_dtypes_ = [np.single, np.double]
         X = check_array(X, dtype=_supported_dtypes_)
@@ -254,7 +254,7 @@ class RandomForestClassifier(skl_RandomForestClassifier):
         self._cached_estimators_ = estimators_
         return estimators_
 
-    def daal_predict(self, X):
+    def _daal_predict(self, X):
         X = self._validate_X_predict(X)
 
         dfc_algorithm = daal4py.decision_forest_classification_prediction(
@@ -269,7 +269,7 @@ class RandomForestClassifier(skl_RandomForestClassifier):
 
 
     def fit(self, X, y):
-        return self.daal_fit(X, y)
+        return self._daal_fit(X, y)
 
 
     def predict(self, X):
@@ -277,7 +277,7 @@ class RandomForestClassifier(skl_RandomForestClassifier):
             check_is_fitted(self)
         else:
             check_is_fitted(self, 'daal_model_')
-        return self.daal_predict(X)
+        return self._daal_predict(X)
 
 
     def _more_tags(self):
@@ -350,7 +350,7 @@ class RandomForestRegressor(skl_RandomForestRegressor):
 
 
     # Intel(R) DAAL only supports "mse" criterion
-    def daal_fit(self, X, y):
+    def _daal_fit(self, X, y):
         self._check_daal_supported_parameters()
         _supported_dtypes_ = [np.double, np.single]
         X = check_array(X, dtype=_supported_dtypes_)
@@ -459,7 +459,7 @@ class RandomForestRegressor(skl_RandomForestRegressor):
 
 
 
-    def daal_predict(self, X):
+    def _daal_predict(self, X):
         if LooseVersion(sklearn_version) >= LooseVersion("0.22"):
             check_is_fitted(self)
         else:
@@ -475,11 +475,11 @@ class RandomForestRegressor(skl_RandomForestRegressor):
 
 
     def fit(self, X, y):
-        return self.daal_fit(X, y)
+        return self._daal_fit(X, y)
 
 
     def predict(self, X):
-        return self.daal_predict(X)
+        return self._daal_predict(X)
 
 
     def _more_tags(self):

--- a/daal4py/sklearn/ensemble/decision_forest.py
+++ b/daal4py/sklearn/ensemble/decision_forest.py
@@ -187,8 +187,7 @@ class RandomForestClassifier(skl_RandomForestClassifier):
             memorySavingMode=False,
             bootstrap=bool(self.bootstrap)
         )
-        if hasattr(self, '_cached_estimators_'):
-            del self._cached_estimators_
+        self._cached_estimators_ = None
         # compute
         dfc_trainingResult = dfc_algorithm.compute(X, y)
 
@@ -206,7 +205,8 @@ class RandomForestClassifier(skl_RandomForestClassifier):
     @property
     def estimators_(self):
         if hasattr(self, '_cached_estimators_'):
-            return self._cached_estimators_
+            if self._cached_estimators_:
+                return self._cached_estimators_
 
         if LooseVersion(sklearn_version) >= LooseVersion("0.22"):
             check_is_fitted(self)
@@ -402,8 +402,7 @@ class RandomForestRegressor(skl_RandomForestRegressor):
             bootstrap=bool(self.bootstrap)
         )
 
-        if hasattr(self, '_cached_estimators_'):
-            del self._cached_estimators_
+        self._cached_estimators_ = None
         dfr_trainingResult = dfr_algorithm.compute(X, y)
 
         # get resulting model
@@ -418,6 +417,9 @@ class RandomForestRegressor(skl_RandomForestRegressor):
 
     @property
     def estimators_(self):
+        if hasattr(self, '_cached_estimators_'):
+            if self._cached_estimators_:
+                return self._cached_estimators_
         if LooseVersion(sklearn_version) >= LooseVersion("0.22"):
             check_is_fitted(self)
         else:

--- a/daal4py/sklearn/ensemble/decision_forest.py
+++ b/daal4py/sklearn/ensemble/decision_forest.py
@@ -169,7 +169,7 @@ class RandomForestClassifier(skl_RandomForestClassifier):
         # create algorithm
         X_fptype = getFPType(X)
         daal_engine_ = daal4py.engines_mt2203(seed=seed_, fptype=X_fptype)
-        _featuresPerNode = _to_absolute_max_features(self.max_features, X.shape[1], is_classification=False)
+        _featuresPerNode = _to_absolute_max_features(self.max_features, X.shape[1], is_classification=True)
 
         dfc_algorithm = daal4py.decision_forest_classification_training(
             nClasses=int(self.n_classes_),

--- a/tests/test_estimators.py
+++ b/tests/test_estimators.py
@@ -7,6 +7,30 @@ from daal4py.sklearn.neighbors import KNeighborsClassifier
 from daal4py.sklearn.ensemble import RandomForestClassifier
 from daal4py.sklearn.ensemble import RandomForestRegressor
 
+def _replace_and_save(md, fns, replacing_fn):
+    """
+    Replaces functions in `fns` list in `md` module with `replacing_fn`.
+
+    Returns the dictionary with functions that were replaced.
+    """
+    saved = dict()
+    for check_f in fns:
+        try:
+            fn = getattr(md, check_f)
+            setattr(md, check_f, replacing_fn)
+            saved[check_f] = fn
+        except:
+            pass
+    return saved
+
+
+def _restore_from_saved(md, saved_dict):
+    """
+    Restores functions in `md` that were replaced in the function above.
+    """
+    for check_f in saved_dict:
+        setattr(md, check_f, saved_dict[check_f])
+
 
 class Test(unittest.TestCase):
     def test_KNeighborsClassifier(self):
@@ -19,14 +43,11 @@ class Test(unittest.TestCase):
         # Skip the test
         def dummy(*args, **kwargs):
             pass
-        try:
-            saved = sklearn.utils.estimator_checks.check_methods_subset_invariance
-            sklearn.utils.estimator_checks.check_methods_subset_invariance = dummy
-        except AttributeError:
-            saved = None
+
+        md = sklearn.utils.estimator_checks
+        saved = _replace_and_save(md, ['check_methods_subset_invariance', 'check_dict_unchanged'], dummy)
         check_estimator(RandomForestClassifier)
-        if saved is not None:
-            sklearn.utils.estimator_checks.check_methods_subset_invariance = saved
+        _restore_from_saved(md, saved)
 
 
     def test_RandomForestRegressor(self):
@@ -36,14 +57,10 @@ class Test(unittest.TestCase):
         # Hence skip that test
         def dummy(*args, **kwargs):
             pass
-        try:
-            saved = sklearn.utils.estimator_checks.check_fit_idempotent
-            sklearn.utils.estimator_checks.check_fit_idempotent = dummy
-        except AttributeError:
-            saved = None
+        md = sklearn.utils.estimator_checks
+        saved = _replace_and_save(md, ['check_methods_subset_invariance', 'check_dict_unchanged'], dummy)
         check_estimator(RandomForestRegressor)
-        if saved is not None:
-            sklearn.utils.estimator_checks.check_fit_idempotent = saved
+        _restore_from_saved(md, saved)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Conversion of DAAL model to list of Scikit-Learn estimators may be 
time consuming, and not needed for predict, unless out-of-bag score
is requested.

Moving the conversion to property allows to compute them on demand.
The result is cached, and reused afterwards.

@Alexander-Makaryev 
@ShvetsKS 

