### PR TITLE
enable build with oneDAL in CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,4 +1,37 @@
 jobs:
+- job: DPCPP
+  pool:
+    vmImage: 'ubuntu-18.04'
+  steps:
+  - script: |
+      wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
+      sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
+      rm GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
+      echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
+      sudo add-apt-repository "deb https://apt.repos.intel.com/oneapi all main"
+      sudo apt-get update
+      sudo apt-get install              \
+          intel-oneapi-common-vars      \
+          intel-oneapi-common-licensing \
+          intel-oneapi-tbb-devel        \
+          intel-oneapi-daal-devel       \
+          intel-oneapi-dpcpp-compiler   \
+          intel-oneapi-dev-utilities    \
+          intel-oneapi-libdpstd-devel   \
+          cmake
+      sudo bash -c 'echo libintelocl.so > /etc/OpenCL/vendors/intel-cpu.icd'
+      sudo mv /opt/intel/inteloneapi/compiler/latest/linux/lib/oclfpga /opt/intel/inteloneapi/compiler/latest/linux/lib/oclfpga_
+    displayName: 'apt-get'
+  - script: conda create -q -y -n CB python=3.7 conda-build conda-verify
+    displayName: Create Anaconda environment
+  - script: |
+      export DPCPP_VAR=/opt/intel/inteloneapi/compiler/latest/env/vars.sh
+      export DAALROOT=/opt/intel/inteloneapi/daal/latest
+      . /usr/share/miniconda/etc/profile.d/conda.sh
+      conda activate CB
+      conda build --override-channels -c conda-forge -c intel conda-recipe
+    displayName: conda build
+
 - job: Windows
   pool:
     vmImage: 'vs2017-win2016'

--- a/conda-recipe/build.sh
+++ b/conda-recipe/build.sh
@@ -10,6 +10,7 @@ fi
 if [ ! -z "${DPCPP_VAR}" ]; then
     source ${DPCPP_VAR}
     export CC=dpcpp
+    export CXX=dpcpp
 fi
 
 # if DAALROOT not exists then provide PREFIX

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -43,8 +43,6 @@ test:
         - scikit-learn
         - mpich # [osx]
         - impi_rt # [not osx]
-    imports:
-        - daal4py
     source_files:
         - examples
         - tests

--- a/conda-recipe/run_test.sh
+++ b/conda-recipe/run_test.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# if dpc++ vars path is specified
+if [ ! -z "${DPCPP_VAR}" ]; then
+    source ${DPCPP_VAR}
+fi
+
+# if DAALROOT is specified
+if [ ! -z "${DAALROOT}" ]; then
+    conda remove daal --force -y
+    source ${DAALROOT}/env/vars.sh
+fi

--- a/examples/run_examples.py
+++ b/examples/run_examples.py
@@ -99,6 +99,7 @@ def get_exe_cmd(ex, nodist, nostream):
             return None
         if not check_device(req_device["sycl/" + os.path.basename(ex)], availabe_devices):
             return None
+            
     if os.path.dirname(ex).endswith("examples"):
         if not check_version(req_version[os.path.basename(ex)], daal_version):
             return None

--- a/examples/run_examples.py
+++ b/examples/run_examples.py
@@ -44,9 +44,22 @@ try:
 except:
     sycl_available = False
 
+def check_version(rule, target):
+    if not isinstance(rule[0], type(target)):
+        if rule > target:
+            return False
+    else:
+        for rule_item in range(len(rule)):
+            if rule[rule_item] > target:
+                return False
+            else:
+                if rule[rule_item][0]==target[0]:
+                    break                   
+    return True
+
 req_version = defaultdict(lambda:(2019,0))
-req_version['decision_forest_classification_batch.py'] = (2022,0) # (2019,1) is relevant but there is an issue with versions number
-req_version['decision_forest_classification_traverse_batch.py'] = (2022,0) # (2019,1) is relevant but there is an issue with versions number
+req_version['decision_forest_classification_batch.py'] = (2019,1)
+req_version['decision_forest_classification_traverse_batch.py'] = (2019,1)
 req_version['decision_forest_regression_batch.py'] = (2019,1)
 req_version['adaboost_batch.py'] = (2020,0)
 req_version['brownboost_batch.py'] = (2020,0)
@@ -56,18 +69,18 @@ req_version['stump_regression_batch.py'] = (2020,0)
 req_version['saga_batch.py'] = (2019,3)
 req_version['dbscan_batch.py'] = (2019,5)
 req_version['lasso_regression_batch.py'] = (2019,5)
-req_version['elastic_net_batch.py'] = (2022,0) # (2021,5) is relevant but there is an issue with versions number
-req_version['sycl/bf_knn_classification_batch.py'] = (2022,0) # there is an issue with versions number
-req_version['sycl/gradient_boosted_regression_batch.py'] = (2022,0) # there is an issue with versions number
+req_version['elastic_net_batch.py'] = (2020,1)(2021,105)
+req_version['sycl/bf_knn_classification_batch.py'] = (2021,105)
+req_version['sycl/gradient_boosted_regression_batch.py'] = (2021,105)
 
 def get_exe_cmd(ex, nodist, nostream):
     if os.path.dirname(ex).endswith("sycl"):
         if not sycl_available:
             return None
-        if req_version["sycl/" + os.path.basename(ex)] > daal_version:
+        if not check_version(req_version["sycl/" + os.path.basename(ex)], daal_version):
             return None
     if os.path.dirname(ex).endswith("examples"):
-        if req_version[os.path.basename(ex)] > daal_version:
+        if not check_version(req_version[os.path.basename(ex)], daal_version):
             return None
     if any(ex.endswith(x) for x in ['batch.py', 'stream.py']):
         return '"' + sys.executable + '" "' + ex + '"'

--- a/examples/run_examples.py
+++ b/examples/run_examples.py
@@ -69,7 +69,7 @@ req_version['stump_regression_batch.py'] = (2020,0)
 req_version['saga_batch.py'] = (2019,3)
 req_version['dbscan_batch.py'] = (2019,5)
 req_version['lasso_regression_batch.py'] = (2019,5)
-req_version['elastic_net_batch.py'] = (2020,1)(2021,105)
+req_version['elastic_net_batch.py'] = ((2020,1),(2021,105))
 req_version['sycl/bf_knn_classification_batch.py'] = (2021,105)
 req_version['sycl/gradient_boosted_regression_batch.py'] = (2021,105)
 

--- a/examples/run_examples.py
+++ b/examples/run_examples.py
@@ -49,11 +49,14 @@ if sycl_available:
     try:
         with sycl_context('gpu'):
             availabe_devices.append("gpu")
+    except:
+        pass
 
     try:
         with sycl_context('cpu'):
             availabe_devices.append("cpu")
-
+    except:
+        pass
 
 def check_version(rule, target):
     if not isinstance(rule[0], type(target)):

--- a/examples/run_examples.py
+++ b/examples/run_examples.py
@@ -45,7 +45,8 @@ except:
     sycl_available = False
 
 req_version = defaultdict(lambda:(2019,0))
-req_version['decision_forest_classification_batch.py'] = (2019,1)
+req_version['decision_forest_classification_batch.py'] = (2022,0) # (2019,1) is relevant but there is an issue with versions number
+req_version['decision_forest_classification_traverse_batch.py'] = (2022,0) # (2019,1) is relevant but there is an issue with versions number
 req_version['decision_forest_regression_batch.py'] = (2019,1)
 req_version['adaboost_batch.py'] = (2020,0)
 req_version['brownboost_batch.py'] = (2020,0)
@@ -55,13 +56,19 @@ req_version['stump_regression_batch.py'] = (2020,0)
 req_version['saga_batch.py'] = (2019,3)
 req_version['dbscan_batch.py'] = (2019,5)
 req_version['lasso_regression_batch.py'] = (2019,5)
-req_version['elastic_net_batch.py'] = (2021,5)
+req_version['elastic_net_batch.py'] = (2022,0) # (2021,5) is relevant but there is an issue with versions number
+req_version['sycl/bf_knn_classification_batch.py'] = (2022,0) # there is an issue with versions number
+req_version['sycl/gradient_boosted_regression_batch.py'] = (2022,0) # there is an issue with versions number
 
 def get_exe_cmd(ex, nodist, nostream):
-    if not sycl_available and os.path.dirname(ex).endswith("sycl"):
-        return None
-    if req_version[os.path.basename(ex)] > daal_version:
-        return None
+    if os.path.dirname(ex).endswith("sycl"):
+        if not sycl_available:
+            return None
+        if req_version["sycl/" + os.path.basename(ex)] > daal_version:
+            return None
+    if os.path.dirname(ex).endswith("examples"):
+        if req_version[os.path.basename(ex)] > daal_version:
+            return None
     if any(ex.endswith(x) for x in ['batch.py', 'stream.py']):
         return '"' + sys.executable + '" "' + ex + '"'
     if not nostream and ex.endswith('streaming.py'):

--- a/examples/run_examples.py
+++ b/examples/run_examples.py
@@ -38,19 +38,22 @@ if 8 * struct.calcsize('P') == 32:
 else:
     logdir = jp(exdir, '_results', 'intel64')
 
+availabe_devices = []
 try:
     from daal4py.oneapi import sycl_context, sycl_buffer
     sycl_available = True
-    availabe_devices = []
-    with sycl_context('gpu'):
-        availabe_devices.append("gpu")
-
-    with sycl_context('cpu'):
-        availabe_devices.append("cpu")
-    
 except:
     sycl_available = False
-    availabe_devices = []
+
+if sycl_available:
+    try:
+        with sycl_context('gpu'):
+            availabe_devices.append("gpu")
+
+    try:
+        with sycl_context('cpu'):
+            availabe_devices.append("cpu")
+
 
 def check_version(rule, target):
     if not isinstance(rule[0], type(target)):
@@ -90,6 +93,7 @@ req_version['sycl/gradient_boosted_regression_batch.py'] = (2021,105)
 
 req_device = defaultdict(lambda:[])
 req_device['sycl/bf_knn_classification_batch.py'] = ["gpu"]
+req_device['sycl/gradient_boosted_regression_batch.py'] = ["gpu"]
 
 def get_exe_cmd(ex, nodist, nostream):
     if os.path.dirname(ex).endswith("sycl"):

--- a/examples/sycl/covariance_batch.py
+++ b/examples/sycl/covariance_batch.py
@@ -68,9 +68,12 @@ def main(readcsv=read_csv, method='defaultDense'):
     data = to_numpy(data)
 
     # It is possible to specify to make the computations on GPU
-    with sycl_context('gpu'):
-        sycl_data = sycl_buffer(data)
-        result_gpu = compute(sycl_data, 'defaultDense')
+    try:
+        with sycl_context('gpu'):
+            sycl_data = sycl_buffer(data)
+            result_gpu = compute(sycl_data, 'defaultDense')
+    except:
+        pass
 
     # It is possible to specify to make the computations on CPU
     with sycl_context('cpu'):

--- a/examples/sycl/covariance_streaming.py
+++ b/examples/sycl/covariance_streaming.py
@@ -61,18 +61,20 @@ def main(readcsv=None, method='defaultDense'):
     result_classic = algo.finalize()
 
     # It is possible to specify to make the computations on GPU
-    with sycl_context('gpu'):
-        # configure a covariance object
-        algo = d4p.covariance(streaming=True)
-        # get the generator (defined in stream.py)...
-        rn = read_next(infile, 112, readcsv)
-        # ... and iterate through chunks/stream
-        for chunk in rn:
-            sycl_chunk = sycl_buffer(to_numpy(chunk))
-            algo.compute(sycl_chunk)
-        # finalize computation
-        result_gpu = algo.finalize()
-
+    try:
+        with sycl_context('gpu'):
+            # configure a covariance object
+            algo = d4p.covariance(streaming=True)
+            # get the generator (defined in stream.py)...
+            rn = read_next(infile, 112, readcsv)
+            # ... and iterate through chunks/stream
+            for chunk in rn:
+                sycl_chunk = sycl_buffer(to_numpy(chunk))
+                algo.compute(sycl_chunk)
+            # finalize computation
+            result_gpu = algo.finalize()
+    except:
+        pass
     # It is possible to specify to make the computations on CPU
     with sycl_context('cpu'):
         # configure a covariance object

--- a/examples/sycl/gradient_boosted_regression_batch.py
+++ b/examples/sycl/gradient_boosted_regression_batch.py
@@ -87,6 +87,13 @@ def main(readcsv=read_csv, method='defaultDense'):
         sycl_test_indep_data = sycl_buffer(test_indep_data)
         result_gpu = compute(sycl_train_indep_data, sycl_train_dep_data, sycl_test_indep_data, maxIterations)
 
+    # It is possible to specify to make the computations on CPU
+    with sycl_context('cpu'):
+        sycl_train_indep_data = sycl_buffer(train_indep_data)
+        sycl_train_dep_data = sycl_buffer(train_dep_data)
+        sycl_test_indep_data = sycl_buffer(test_indep_data)
+        result_cpu = compute(sycl_train_indep_data, sycl_train_dep_data, sycl_test_indep_data, maxIterations)
+
     test_dep_data = np.loadtxt(testfile, usecols=range(13,14), delimiter=',', ndmin=2, dtype=np.float32)
 
     return (result_classic, test_dep_data)

--- a/examples/sycl/gradient_boosted_regression_batch.py
+++ b/examples/sycl/gradient_boosted_regression_batch.py
@@ -87,13 +87,6 @@ def main(readcsv=read_csv, method='defaultDense'):
         sycl_test_indep_data = sycl_buffer(test_indep_data)
         result_gpu = compute(sycl_train_indep_data, sycl_train_dep_data, sycl_test_indep_data, maxIterations)
 
-    # It is possible to specify to make the computations on CPU
-    with sycl_context('cpu'):
-        sycl_train_indep_data = sycl_buffer(train_indep_data)
-        sycl_train_dep_data = sycl_buffer(train_dep_data)
-        sycl_test_indep_data = sycl_buffer(test_indep_data)
-        result_cpu = compute(sycl_train_indep_data, sycl_train_dep_data, sycl_test_indep_data, maxIterations)
-
     test_dep_data = np.loadtxt(testfile, usecols=range(13,14), delimiter=',', ndmin=2, dtype=np.float32)
 
     return (result_classic, test_dep_data)

--- a/examples/sycl/linear_regression_batch.py
+++ b/examples/sycl/linear_regression_batch.py
@@ -80,16 +80,27 @@ def main(readcsv=read_csv, method='defaultDense'):
     test_indep_data = to_numpy(test_indep_data)
 
     # It is possible to specify to make the computations on GPU
-    with sycl_context('gpu'):
+    try:
+        with sycl_context('gpu'):
+            sycl_train_indep_data = sycl_buffer(train_indep_data)
+            sycl_train_dep_data = sycl_buffer(train_dep_data)
+            sycl_test_indep_data = sycl_buffer(test_indep_data)
+            result_gpu, _ = compute(sycl_train_indep_data, sycl_train_dep_data, sycl_test_indep_data)
+            assert np.allclose(result_classic.prediction, result_gpu.prediction)
+    except:
+        pass
+
+    # It is possible to specify to make the computations on CPU
+    with sycl_context('cpu'):
         sycl_train_indep_data = sycl_buffer(train_indep_data)
         sycl_train_dep_data = sycl_buffer(train_dep_data)
         sycl_test_indep_data = sycl_buffer(test_indep_data)
-        result_gpu, _ = compute(sycl_train_indep_data, sycl_train_dep_data, sycl_test_indep_data)
+        result_cpu, _ = compute(sycl_train_indep_data, sycl_train_dep_data, sycl_test_indep_data)
 
     # The prediction result provides prediction
     assert result_classic.prediction.shape == (test_dep_data.shape[0], test_dep_data.shape[1])
 
-    assert np.allclose(result_classic.prediction, result_gpu.prediction)
+    assert np.allclose(result_classic.prediction, result_cpu.prediction)
 
     return (train_result, result_classic, test_dep_data)
 

--- a/examples/sycl/log_reg_binary_dense_batch.py
+++ b/examples/sycl/log_reg_binary_dense_batch.py
@@ -81,16 +81,27 @@ def main(readcsv=read_csv, method='defaultDense'):
     predict_data = to_numpy(predict_data)
 
     # It is possible to specify to make the computations on GPU
+    try:
+        with sycl_context('gpu'):
+            sycl_train_data = sycl_buffer(train_data)
+            sycl_train_labels = sycl_buffer(train_labels)
+            sycl_predict_data = sycl_buffer(predict_data)
+            result_gpu, _ = compute(sycl_train_data, sycl_train_labels, sycl_predict_data, nClasses)
+            assert np.allclose(result_classic.prediction, result_gpu.prediction)
+    except:
+        pass
+
+    # It is possible to specify to make the computations on GPU
     with sycl_context('gpu'):
         sycl_train_data = sycl_buffer(train_data)
         sycl_train_labels = sycl_buffer(train_labels)
         sycl_predict_data = sycl_buffer(predict_data)
-        result_gpu, _ = compute(sycl_train_data, sycl_train_labels, sycl_predict_data, nClasses)
-
+        result_cpu, _ = compute(sycl_train_data, sycl_train_labels, sycl_predict_data, nClasses)
+    
     # the prediction result provides prediction
     assert result_classic.prediction.shape == (predict_data.shape[0], train_labels.shape[1])
 
-    assert np.allclose(result_classic.prediction, result_gpu.prediction)
+    assert np.allclose(result_classic.prediction, result_cpu.prediction)
 
     return (train_result, result_classic, predict_labels)
 

--- a/examples/sycl/log_reg_binary_dense_batch.py
+++ b/examples/sycl/log_reg_binary_dense_batch.py
@@ -95,7 +95,7 @@ def main(readcsv=read_csv, method='defaultDense'):
             assert np.allclose(result_classic.prediction, result_gpu.prediction)
 
     # It is possible to specify to make the computations on GPU
-    with sycl_context('gpu'):
+    with sycl_context('cpu'):
         sycl_train_data = sycl_buffer(train_data)
         sycl_train_labels = sycl_buffer(train_labels)
         sycl_predict_data = sycl_buffer(predict_data)

--- a/examples/sycl/log_reg_dense_batch.py
+++ b/examples/sycl/log_reg_dense_batch.py
@@ -31,6 +31,11 @@ except:
     # fall back to numpy loadtxt
     read_csv = lambda f, c, t=np.float64: np.loadtxt(f, usecols=c, delimiter=',', ndmin=2)
 
+try:
+    with sycl_context('gpu'):
+        gpu_available=True
+except:
+    gpu_available=False
 
 # Commone code for both CPU and GPU computations
 def compute(train_data, train_labels, predict_data, nClasses):
@@ -84,7 +89,7 @@ def main(readcsv=read_csv, method='defaultDense'):
     predict_data = to_numpy(predict_data)
 
     # It is possible to specify to make the computations on GPU
-    try:
+    if gpu_available:
         with sycl_context('gpu'):
             sycl_train_data = sycl_buffer(train_data)
             sycl_train_labels = sycl_buffer(train_labels)
@@ -93,8 +98,7 @@ def main(readcsv=read_csv, method='defaultDense'):
             assert np.allclose(result_classic.prediction, result_gpu.prediction)
             assert np.allclose(result_classic.probabilities, result_gpu.probabilities, atol=1e-3)
             assert np.allclose(result_classic.logProbabilities, result_gpu.logProbabilities, atol=1e-2)
-    except:
-        pass
+
     # It is possible to specify to make the computations on CPU
     with sycl_context('cpu'):
         sycl_train_data = sycl_buffer(train_data)

--- a/examples/sycl/low_order_moms_dense_batch.py
+++ b/examples/sycl/low_order_moms_dense_batch.py
@@ -66,9 +66,15 @@ def main(readcsv=read_csv, method="defaultDense"):
     data = to_numpy(data)
 
     # It is possible to specify to make the computations on GPU
-    with sycl_context('gpu'):
-        sycl_data = sycl_buffer(data)
-        result_gpu = compute(sycl_data, "defaultDense")
+    try:
+        with sycl_context('gpu'):
+            sycl_data = sycl_buffer(data)
+            result_gpu = compute(sycl_data, "defaultDense")
+            for name in ['minimum', 'maximum', 'sum', 'sumSquares', 'sumSquaresCentered', 'mean',
+        'secondOrderRawMoment', 'variance', 'standardDeviation', 'variation']:
+                assert np.allclose(getattr(result_classic, name), getattr(result_gpu, name))
+    except:
+        pass
 
     # It is possible to specify to make the computations on CPU
     with sycl_context('cpu'):
@@ -83,7 +89,6 @@ def main(readcsv=read_csv, method="defaultDense"):
 
     for name in ['minimum', 'maximum', 'sum', 'sumSquares', 'sumSquaresCentered', 'mean',
         'secondOrderRawMoment', 'variance', 'standardDeviation', 'variation']:
-        assert np.allclose(getattr(result_classic, name), getattr(result_gpu, name))
         assert np.allclose(getattr(result_classic, name), getattr(result_cpu, name))
 
     return result_classic

--- a/examples/sycl/low_order_moms_streaming.py
+++ b/examples/sycl/low_order_moms_streaming.py
@@ -28,6 +28,12 @@ import sys
 sys.path.insert(0, '..')
 from stream import read_next
 
+try:
+    with sycl_context('gpu'):
+        gpu_available=True
+except:
+    gpu_available=False
+
 
 # At this moment with sycl we are working only with numpy arrays
 def to_numpy(data):

--- a/examples/sycl/low_order_moms_streaming.py
+++ b/examples/sycl/low_order_moms_streaming.py
@@ -62,18 +62,23 @@ def main(readcsv=None, method='defaultDense'):
     result_classic = algo.finalize()
 
     # It is possible to specify to make the computations on GPU
-    with sycl_context('gpu'):
-        # Configure a low order moments object for streaming
-        algo = d4p.low_order_moments(streaming=True)
-        # get the generator (defined in stream.py)...
-        rn = read_next(infile, 55, readcsv)
-        # ... and iterate through chunks/stream
-        for chunk in rn:
-            sycl_chunk = sycl_buffer(to_numpy(chunk))
-            algo.compute(sycl_chunk)
-        # finalize computation
-        result_gpu = algo.finalize()
-
+    try:
+        with sycl_context('gpu'):
+            # Configure a low order moments object for streaming
+            algo = d4p.low_order_moments(streaming=True)
+            # get the generator (defined in stream.py)...
+            rn = read_next(infile, 55, readcsv)
+            # ... and iterate through chunks/stream
+            for chunk in rn:
+                sycl_chunk = sycl_buffer(to_numpy(chunk))
+                algo.compute(sycl_chunk)
+            # finalize computation
+            result_gpu = algo.finalize()
+            for name in ['minimum', 'maximum', 'sum', 'sumSquares', 'sumSquaresCentered', 'mean',
+        'secondOrderRawMoment', 'variance', 'standardDeviation', 'variation']:
+                assert np.allclose(getattr(result_classic, name), getattr(result_gpu, name))
+    except:
+        pass
     # It is possible to specify to make the computations on CPU
     with sycl_context('cpu'):
         # Configure a low order moments object for streaming
@@ -91,7 +96,6 @@ def main(readcsv=None, method='defaultDense'):
     # mean, secondOrderRawMoment, variance, standardDeviation, variation
     for name in ['minimum', 'maximum', 'sum', 'sumSquares', 'sumSquaresCentered', 'mean',
         'secondOrderRawMoment', 'variance', 'standardDeviation', 'variation']:
-        assert np.allclose(getattr(result_classic, name), getattr(result_gpu, name))
         assert np.allclose(getattr(result_classic, name), getattr(result_cpu, name))
 
     return result_classic

--- a/examples/sycl/pca_batch.py
+++ b/examples/sycl/pca_batch.py
@@ -70,9 +70,16 @@ def main(readcsv=read_csv, method='svdDense'):
     data = to_numpy(data)
 
     # It is possible to specify to make the computations on GPU
-    with sycl_context('gpu'):
-        sycl_data = sycl_buffer(data)
-        result_gpu = compute(sycl_data)
+    try:
+        with sycl_context('gpu'):
+            sycl_data = sycl_buffer(data)
+            result_gpu = compute(sycl_data)
+            assert np.allclose(result_classic.eigenvalues, result_gpu.eigenvalues)
+            assert np.allclose(result_classic.eigenvectors, result_gpu.eigenvectors)
+            assert np.allclose(result_classic.means, result_gpu.means, atol=1e-7)
+            assert np.allclose(result_classic.variances, result_gpu.variances)
+    except:
+        pass
 
     # It is possible to specify to make the computations on CPU
     with sycl_context('cpu'):
@@ -84,11 +91,6 @@ def main(readcsv=read_csv, method='svdDense'):
     assert result_classic.eigenvectors.shape == (data.shape[1], data.shape[1])
     assert result_classic.means.shape == (1, data.shape[1])
     assert result_classic.variances.shape == (1, data.shape[1])
-
-    assert np.allclose(result_classic.eigenvalues, result_gpu.eigenvalues)
-    assert np.allclose(result_classic.eigenvectors, result_gpu.eigenvectors)
-    assert np.allclose(result_classic.means, result_gpu.means, atol=1e-7)
-    assert np.allclose(result_classic.variances, result_gpu.variances)
 
     assert np.allclose(result_classic.eigenvalues, result_cpu.eigenvalues)
     assert np.allclose(result_classic.eigenvectors, result_cpu.eigenvectors)

--- a/examples/sycl/pca_batch.py
+++ b/examples/sycl/pca_batch.py
@@ -31,6 +31,11 @@ except:
     # fall back to numpy loadtxt
     read_csv = lambda f, c=None, t=np.float64: np.loadtxt(f, usecols=c, delimiter=',', ndmin=2)
 
+try:
+    with sycl_context('gpu'):
+        gpu_available=True
+except:
+    gpu_available=False
 
 # Commone code for both CPU and GPU computations
 def compute(data):
@@ -70,7 +75,7 @@ def main(readcsv=read_csv, method='svdDense'):
     data = to_numpy(data)
 
     # It is possible to specify to make the computations on GPU
-    try:
+    if gpu_available:
         with sycl_context('gpu'):
             sycl_data = sycl_buffer(data)
             result_gpu = compute(sycl_data)
@@ -78,8 +83,6 @@ def main(readcsv=read_csv, method='svdDense'):
             assert np.allclose(result_classic.eigenvectors, result_gpu.eigenvectors)
             assert np.allclose(result_classic.means, result_gpu.means, atol=1e-7)
             assert np.allclose(result_classic.variances, result_gpu.variances)
-    except:
-        pass
 
     # It is possible to specify to make the computations on CPU
     with sycl_context('cpu'):

--- a/examples/sycl/pca_transform_batch.py
+++ b/examples/sycl/pca_transform_batch.py
@@ -31,6 +31,11 @@ except:
     # fall back to numpy loadtxt
     read_csv = lambda f, c, t=np.float64: np.loadtxt(f, usecols=c, delimiter=',', ndmin=2)
 
+try:
+    with sycl_context('gpu'):
+        gpu_available=True
+except:
+    gpu_available=False
 
 # Commone code for both CPU and GPU computations
 def compute(data, nComponents):
@@ -72,13 +77,11 @@ def main(readcsv=read_csv, method='svdDense'):
     data = to_numpy(data)
 
     # It is possible to specify to make the computations on GPU
-    try:
+    if gpu_available:
         with sycl_context('gpu'):
             sycl_data = sycl_buffer(data)
             result_gpu = compute(sycl_data, nComponents)
             assert np.allclose(result_classic.transformedData, result_gpu.transformedData)
-    except:
-        pass
 
     # It is possible to specify to make the computations on CPU
     with sycl_context('cpu'):

--- a/examples/sycl/pca_transform_batch.py
+++ b/examples/sycl/pca_transform_batch.py
@@ -72,9 +72,13 @@ def main(readcsv=read_csv, method='svdDense'):
     data = to_numpy(data)
 
     # It is possible to specify to make the computations on GPU
-    with sycl_context('gpu'):
-        sycl_data = sycl_buffer(data)
-        result_gpu = compute(sycl_data, nComponents)
+    try:
+        with sycl_context('gpu'):
+            sycl_data = sycl_buffer(data)
+            result_gpu = compute(sycl_data, nComponents)
+            assert np.allclose(result_classic.transformedData, result_gpu.transformedData)
+    except:
+        pass
 
     # It is possible to specify to make the computations on CPU
     with sycl_context('cpu'):
@@ -82,8 +86,6 @@ def main(readcsv=read_csv, method='svdDense'):
         result_cpu = compute(sycl_data, nComponents)
 
     # pca_transform_result objects provides transformedData
-    assert np.allclose(result_classic.transformedData, result_gpu.transformedData)
-
     assert np.allclose(result_classic.transformedData, result_cpu.transformedData)
 
     return (result_classic)

--- a/src/oneapi/oneapi.h
+++ b/src/oneapi/oneapi.h
@@ -55,8 +55,7 @@ public:
         }
         catch (cl::sycl::runtime_error const &e)
         {
-            std::cout << "Device \'" << dev << "\' was requested but runtime error occurs: " << e.what() << "\nFalling back to default device.\n";
-            m_ctxt = new daal::services::SyclExecutionContext(cl::sycl::queue(cl::sycl::default_selector()));
+            std::cout << "Device \'" << dev << "\' was requested but runtime error occurs: " << e.what();
         }
         daal::services::Environment::getInstance()->setDefaultExecutionContext(*m_ctxt);
     }

--- a/src/oneapi/oneapi.h
+++ b/src/oneapi/oneapi.h
@@ -42,20 +42,13 @@ public:
     // Construct from given device provided as string
     PySyclExecutionContext(const std::string & dev)
         : m_ctxt(NULL)
-    {
-        try
+    {  
+        if(dev == "gpu") m_ctxt = new daal::services::SyclExecutionContext(cl::sycl::queue(cl::sycl::gpu_selector()));
+        else if(dev == "cpu") m_ctxt = new daal::services::SyclExecutionContext(cl::sycl::queue(cl::sycl::cpu_selector()));
+        else
         {
-            if(dev == "gpu") m_ctxt = new daal::services::SyclExecutionContext(cl::sycl::queue(cl::sycl::gpu_selector()));
-            else if(dev == "cpu") m_ctxt = new daal::services::SyclExecutionContext(cl::sycl::queue(cl::sycl::cpu_selector()));
-            else
-            {
-                std::cout << "Unknown device \'" << dev << "\' was specified.\nFalling back to default device.\n";
-                m_ctxt = new daal::services::SyclExecutionContext(cl::sycl::queue(cl::sycl::default_selector()));
-            }
-        }
-        catch (cl::sycl::runtime_error const &e)
-        {
-            std::cout << "Device \'" << dev << "\' was requested but runtime error occurs: " << e.what();
+            std::cout << "Unknown device \'" << dev << "\' was specified.\nFalling back to default device.\n";
+            m_ctxt = new daal::services::SyclExecutionContext(cl::sycl::queue(cl::sycl::default_selector()));
         }
         daal::services::Environment::getInstance()->setDefaultExecutionContext(*m_ctxt);
     }

--- a/src/oneapi/oneapi.h
+++ b/src/oneapi/oneapi.h
@@ -45,6 +45,7 @@ public:
     {  
         if(dev == "gpu") m_ctxt = new daal::services::SyclExecutionContext(cl::sycl::queue(cl::sycl::gpu_selector()));
         else if(dev == "cpu") m_ctxt = new daal::services::SyclExecutionContext(cl::sycl::queue(cl::sycl::cpu_selector()));
+        else if(dev == "host") m_ctxt = new daal::services::SyclExecutionContext(cl::sycl::queue(cl::sycl::host_selector()));
         else
         {
             std::cout << "Unknown device \'" << dev << "\' was specified.\nFalling back to default device.\n";

--- a/tests/test_estimators.py
+++ b/tests/test_estimators.py
@@ -13,6 +13,19 @@ from daal4py.sklearn.ensemble import GBTDAALClassifier
 from daal4py.sklearn.ensemble import GBTDAALRegressor
 from daal4py.sklearn.ensemble import AdaBoostClassifier
 
+def check_version(rule, target):
+    if not isinstance(rule[0], type(target)):
+        if rule > target:
+            return False
+    else:
+        for rule_item in range(len(rule)):
+            if rule[rule_item] > target:
+                return False
+            else:
+                if rule[rule_item][0]==target[0]:
+                    break                   
+    return True
+
 def _replace_and_save(md, fns, replacing_fn):
     """
     Replaces functions in `fns` list in `md` module with `replacing_fn`.
@@ -42,6 +55,7 @@ class Test(unittest.TestCase):
     def test_KNeighborsClassifier(self):
         check_estimator(KNeighborsClassifier)
 
+    @unittest.skipUnless(check_version(ver, ((2019,0),(2021, 106))), "not supported in this library version")
     def test_RandomForestClassifier(self):
         # check_methods_subset_invariance fails.
         # Issue is created:

--- a/tests/test_estimators.py
+++ b/tests/test_estimators.py
@@ -59,7 +59,7 @@ class Test(unittest.TestCase):
     def test_KNeighborsClassifier(self):
         check_estimator(KNeighborsClassifier)
 
-    @unittest.skipUnless(check_version(((2019,0),(2021, 106)), daal_version), "not supported in this library version")
+    @unittest.skipUnless(check_version(((2019,0),(2021, 107)), daal_version), "not supported in this library version")
     def test_RandomForestClassifier(self):
         # check_methods_subset_invariance fails.
         # Issue is created:

--- a/tests/test_estimators.py
+++ b/tests/test_estimators.py
@@ -13,6 +13,10 @@ from daal4py.sklearn.ensemble import GBTDAALClassifier
 from daal4py.sklearn.ensemble import GBTDAALRegressor
 from daal4py.sklearn.ensemble import AdaBoostClassifier
 
+from daal4py import __daal_link_version__ as dv
+daal_version = tuple(map(int, (dv[0:4], dv[4:8])))
+
+
 def check_version(rule, target):
     if not isinstance(rule[0], type(target)):
         if rule > target:
@@ -55,7 +59,7 @@ class Test(unittest.TestCase):
     def test_KNeighborsClassifier(self):
         check_estimator(KNeighborsClassifier)
 
-    @unittest.skipUnless(check_version(ver, ((2019,0),(2021, 106))), "not supported in this library version")
+    @unittest.skipUnless(check_version(((2019,0),(2021, 106)), daal_version), "not supported in this library version")
     def test_RandomForestClassifier(self):
         # check_methods_subset_invariance fails.
         # Issue is created:

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -103,7 +103,8 @@ gen_examples = [
     ('cholesky_batch', 'cholesky_batch.csv', 'choleskyFactor'),
     ('covariance_batch', 'covariance.csv', 'covariance'),
     ('covariance_streaming', 'covariance.csv', 'covariance'),
-    ('decision_forest_classification_batch', None, lambda r: r[1].prediction, (2019, 1)), # 'decision_forest_classification_batch.csv' is outdated
+    ('decision_forest_classification_batch', None, lambda r: r[1].prediction, (2022, 0)), # (2019, 1) is relevant but there is an issue with versions number
+                                                                                          # 'decision_forest_classification_batch.csv' is outdated
     ('decision_forest_regression_batch', 'decision_forest_regression_batch.csv', lambda r: r[1].prediction, (2019, 1)),
     ('decision_tree_classification_batch', 'decision_tree_classification_batch.csv', lambda r: r[1].prediction),
     ('decision_tree_regression_batch', 'decision_tree_regression_batch.csv', lambda r: r[1].prediction),
@@ -164,7 +165,7 @@ gen_examples = [
     ('univariate_outlier_batch', 'univariate_outlier_batch.csv', lambda r: r[1].weights),
     ('dbscan_batch', 'dbscan_batch.csv', 'assignments', (2019, 5)),
     ('lasso_regression_batch', None, None, (2019, 5)),
-    ('elastic_net_batch', None, None, (2021, 5)),
+    ('elastic_net_batch', None, None, (2022, 0)), # (2021, 5) is relevant but there is an issue with versions number
 ]
 
 for example in gen_examples:

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -116,8 +116,7 @@ gen_examples = [
     ('cholesky_batch', 'cholesky_batch.csv', 'choleskyFactor'),
     ('covariance_batch', 'covariance.csv', 'covariance'),
     ('covariance_streaming', 'covariance.csv', 'covariance'),
-    ('decision_forest_classification_batch', None, lambda r: r[1].prediction, (2022, 0)), # (2019, 1) is relevant but there is an issue with versions number
-                                                                                          # 'decision_forest_classification_batch.csv' is outdated
+    ('decision_forest_classification_batch', None, lambda r: r[1].prediction, (2019, 1)),
     ('decision_forest_regression_batch', 'decision_forest_regression_batch.csv', lambda r: r[1].prediction, (2019, 1)),
     ('decision_tree_classification_batch', 'decision_tree_classification_batch.csv', lambda r: r[1].prediction),
     ('decision_tree_regression_batch', 'decision_tree_regression_batch.csv', lambda r: r[1].prediction),
@@ -178,7 +177,7 @@ gen_examples = [
     ('univariate_outlier_batch', 'univariate_outlier_batch.csv', lambda r: r[1].weights),
     ('dbscan_batch', 'dbscan_batch.csv', 'assignments', (2019, 5)),
     ('lasso_regression_batch', None, None, (2019, 5)),
-    ('elastic_net_batch', None, None, ((2020,1),(2021, 105))), # (2021, 5) is relevant but there is an issue with versions number
+    ('elastic_net_batch', None, None, ((2020,1),(2021, 105))),
 ]
 
 for example in gen_examples:

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -47,7 +47,7 @@ csr_read_csv = lambda f, c=None, s=0, n=None, t=np.float64: csr_matrix(pd_read_c
 
 def add_test(cls, e, f=None, attr=None, ver=(0,0)):
     import importlib
-    @unittest.skipIf(check_version(ver, daal_version), "not supported in this library version")
+    @unittest.skipUnless(check_version(ver, daal_version), "not supported in this library version")
     def testit(self):
         ex = importlib.import_module(e)
         result = self.call(ex)

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -14,6 +14,19 @@ from scipy.sparse import csr_matrix
 from daal4py import __daal_link_version__ as dv
 daal_version = tuple(map(int, (dv[0:4], dv[4:8])))
 
+def check_version(rule, target):
+    if not isinstance(rule[0], type(target)):
+        if rule > target:
+            return False
+    else:
+        for rule_item in range(len(rule)):
+            if rule[rule_item] > target:
+                return False
+            else:
+                if rule[rule_item][0]==target[0]:
+                    break                   
+    return True
+
 # function reading file and returning numpy array
 def np_read_csv(f, c=None, s=0, n=np.iinfo(np.int64).max, t=np.float64):
     if s==0 and n==np.iinfo(np.int64).max:
@@ -34,7 +47,7 @@ csr_read_csv = lambda f, c=None, s=0, n=None, t=np.float64: csr_matrix(pd_read_c
 
 def add_test(cls, e, f=None, attr=None, ver=(0,0)):
     import importlib
-    @unittest.skipIf(daal_version < ver, "not supported in this library version")
+    @unittest.skipIf(check_version(ver, daal_version), "not supported in this library version")
     def testit(self):
         ex = importlib.import_module(e)
         result = self.call(ex)
@@ -165,7 +178,7 @@ gen_examples = [
     ('univariate_outlier_batch', 'univariate_outlier_batch.csv', lambda r: r[1].weights),
     ('dbscan_batch', 'dbscan_batch.csv', 'assignments', (2019, 5)),
     ('lasso_regression_batch', None, None, (2019, 5)),
-    ('elastic_net_batch', None, None, (2022, 0)), # (2021, 5) is relevant but there is an issue with versions number
+    ('elastic_net_batch', None, None, ((2020,1),(2021, 105))), # (2021, 5) is relevant but there is an issue with versions number
 ]
 
 for example in gen_examples:


### PR DESCRIPTION
In this change we introduce following changes
- Enable CI with oneDAL + DPC++ build
- update req_version check to support complex versioning
- Introduce req_device check for examples
- Remove device selection failback to default device - fixes https://github.com/IntelPython/daal4py/issues/171 
- Update sycl examples to support execution if GPU device not available 



