### PR TITLE
install threadpoolctl - required dependency of sklearn in master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,6 +71,7 @@ jobs:
             conda activate bld
             conda install -y --override-channels -c intel cython
             conda install -q /tmp/out/*/daal4py-*.tar.bz2
+            conda install -c conda-forge threadpoolctl
             git clone https://github.com/scikit-learn/scikit-learn.git
             pushd scikit-learn && python setup.py install && popd
             conda list

--- a/daal4py/sklearn/svm/_svm_0_22.py
+++ b/daal4py/sklearn/svm/_svm_0_22.py
@@ -262,8 +262,14 @@ def _daal4py_fit(self, X, y_inp, kernel):
     else:
         self._n_support = np.array([np.sum(indices == i) for i, c in enumerate(self.classes_)], dtype=np.int32)
 
-    self.probA_ = np.empty(0)
-    self.probB_ = np.empty(0)
+    try:
+        self.probA_ = np.empty(0)
+        self.probB_ = np.empty(0)
+    except AttributeError:
+        # in master probA_ and probB_ are deprecated read-only attributes
+        self._probA = np.empty(0)
+        self._probB = np.empty(0)
+
 
     return
 


### PR DESCRIPTION
@fschlimb @Alexander-Makaryev 

Scikit-Learn has added a dependency on `threadpoolctl` [package](https://github.com/joblib/threadpoolctl) in master. 

The script to build Scikit-Learn from master branch now installs `threadpoolctl` from conda-forge.