### PR TITLE
_daal4py_loss_and_grad must ensure gradient is copied out of the resu…

### DIFF
--- a/daal4py/sklearn/linear_model/logistic_loss.py
+++ b/daal4py/sklearn/linear_model/logistic_loss.py
@@ -89,7 +89,7 @@ def _daal4py_loss_and_grad(beta, objF_instance, X, y, n):
     beta_ = make2d(beta)
     res = objF_instance.compute(X, y, beta_)
     gr = res.gradientIdx.ravel()
-    gr *= n
+    gr = gr * n # force copy
     v = res.valueIdx[0,0]
     v *= n
     return (v, gr)
@@ -114,8 +114,8 @@ def _daal4py_grad_(beta, objF_instance, X, y, n, l2_unused):
     # Copy is needed for newton-cg to work correctly
     # Otherwise evaluation at nearby point in line search
     # overwrites gradient at the starting point
-    gr = res.gradientIdx.ravel().copy()
-    gr *= n
+    gr = res.gradientIdx.ravel()
+    gr = gr * n # force copy
     return gr
 
 
@@ -124,8 +124,8 @@ def _daal4py_grad_hess_(beta, objF_instance, X, y, n, l2):
     if beta_.shape[1] != 1 and beta_.shape[0] == 1:
         beta_ = beta_.T
     res = objF_instance.compute(X, y, beta_)
-    gr = res.gradientIdx.ravel().copy()
-    gr *= n
+    gr = res.gradientIdx.ravel()
+    gr = gr * n
     
     if isinstance(objF_instance, daal4py.optimization_solver_logistic_loss):
         # dealing with binary logistic regression


### PR DESCRIPTION
…lt class

The memory for the gradient and value is allocated during algorithm construction.
The algorithm is reused between iterations of LBFGS. If copy is not made, adverse
overwriting ocurrs, and solver raises abnormal line search termination error.

This change fixes convergence warnings added in 0.22, such as

```
Increase the number of iterations (max_iter) or scale the data as shown in:
    https://scikit-learn.org/stable/modules/preprocessing.html
Please also refer to the documentation for alternative solver options:
    https://scikit-learn.org/stable/modules/linear_model.html#logistic-regression
  extra_warning_msg=_LOGISTIC_SOLVER_CONVERGENCE_MSG)
/localdisk/work/lib/python3.7/site-packages/daal4py/sklearn/linear_model/_logistic_path_0_22.py:859: ConvergenceWarning: lbfgs failed to conv
erge (status=2):
ABNORMAL_TERMINATION_IN_LNSRCH.
```

when running `scikit-learn_bench/sklearn/log_reg.py`.