### PR TITLE
update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Without conda-build you have to manually setup your environment before building 
 ## Setting up a build environment
 The easiest path for getting cython, DAAL, TBB, MPI etc. is by creating a conda environment and setting environment variables:
 ```
-conda create -n DAAL4PY -c intel python=3.6 impi-devel tbb-devel daal daal-include cython jinja2 numpy -c conda-forge clang-tools
+conda create -n DAAL4PY python=3.6 impi-devel tbb-devel daal daal-include cython jinja2 numpy clang-tools -c intel -c conda-forge
 conda activate DAAL4PY
 export TBBROOT=$CONDA_PREFIX
 export DAALROOT=$CONDA_PREFIX


### PR DESCRIPTION
Running this line of documentation 
```conda create -n DAAL4PY -c intel python=3.6 impi-devel tbb-devel daal daal-include cython jinja2 numpy -c conda-forge clang-tools``` 
returns ```conda: error: unrecognized arguments: clang-tools```.
 According to the conda documentation, we can rewrite it as follows: 
```bash
$ conda install <packages> -c <first channel> -c <second channel>
```

Priority of channels decreases from left to right - the first argument is higher priority than the second.