### PR TITLE
Throw error for not supported device and disable failback

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,6 +9,7 @@ jobs:
       rm GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
       echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
       sudo add-apt-repository -y "deb https://apt.repos.intel.com/oneapi all main"
+      sudo add-apt-repository -y ppa:intel-opencl/intel-opencl
       sudo apt-get update
       sudo apt-get install              \
           intel-oneapi-common-vars      \
@@ -19,7 +20,9 @@ jobs:
           intel-oneapi-dev-utilities    \
           intel-oneapi-libdpstd-devel   \
           cmake                         \
-          opencl-headers
+          opencl-headers                \
+          libze-loader                  \
+          libze-intel-gpu
       sudo bash -c 'echo libintelocl.so > /etc/OpenCL/vendors/intel-cpu.icd'
       sudo mv -f /opt/intel/inteloneapi/compiler/latest/linux/lib/oclfpga /opt/intel/inteloneapi/compiler/latest/linux/lib/oclfpga_
     displayName: 'apt-get'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,7 +18,8 @@ jobs:
           intel-oneapi-dpcpp-compiler   \
           intel-oneapi-dev-utilities    \
           intel-oneapi-libdpstd-devel   \
-          cmake
+          cmake                         \
+          opencl-headers
       sudo bash -c 'echo libintelocl.so > /etc/OpenCL/vendors/intel-cpu.icd'
       sudo mv -f /opt/intel/inteloneapi/compiler/latest/linux/lib/oclfpga /opt/intel/inteloneapi/compiler/latest/linux/lib/oclfpga_
     displayName: 'apt-get'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,8 +18,10 @@ jobs:
           intel-oneapi-dpcpp-compiler   \
           intel-oneapi-dev-utilities    \
           intel-oneapi-libdpstd-devel   \
-          cmake                         \
-          intel-opencl-icd
+          cmake
+      sudo add-apt-repository ppa:intel-opencl/intel-opencl
+      sudo apt update
+      sudo apt install libze-loader libze-intel-gpu
       sudo bash -c 'echo libintelocl.so > /etc/OpenCL/vendors/intel-cpu.icd'
       sudo mv -f /opt/intel/inteloneapi/compiler/latest/linux/lib/oclfpga /opt/intel/inteloneapi/compiler/latest/linux/lib/oclfpga_
     displayName: 'apt-get'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,7 +8,8 @@ jobs:
       sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
       rm GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
       echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
-      sudo add-apt-repository "deb https://apt.repos.intel.com/oneapi all main"
+      sudo add-apt-repository -y "deb https://apt.repos.intel.com/oneapi all main"
+      sudo add-apt-repository -y ppa:intel-opencl/intel-opencl
       sudo apt-get update
       sudo apt-get install              \
           intel-oneapi-common-vars      \
@@ -18,10 +19,9 @@ jobs:
           intel-oneapi-dpcpp-compiler   \
           intel-oneapi-dev-utilities    \
           intel-oneapi-libdpstd-devel   \
-          cmake
-      sudo add-apt-repository ppa:intel-opencl/intel-opencl
-      sudo apt update
-      sudo apt install libze-loader libze-intel-gpu
+          cmake                         \
+          libze-loader                  \
+          libze-intel-gpu
       sudo bash -c 'echo libintelocl.so > /etc/OpenCL/vendors/intel-cpu.icd'
       sudo mv -f /opt/intel/inteloneapi/compiler/latest/linux/lib/oclfpga /opt/intel/inteloneapi/compiler/latest/linux/lib/oclfpga_
     displayName: 'apt-get'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,7 +18,8 @@ jobs:
           intel-oneapi-dpcpp-compiler   \
           intel-oneapi-dev-utilities    \
           intel-oneapi-libdpstd-devel   \
-          cmake
+          cmake                         \
+          intel-opencl-icd
       sudo bash -c 'echo libintelocl.so > /etc/OpenCL/vendors/intel-cpu.icd'
       sudo mv /opt/intel/inteloneapi/compiler/latest/linux/lib/oclfpga /opt/intel/inteloneapi/compiler/latest/linux/lib/oclfpga_
     displayName: 'apt-get'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,7 +9,6 @@ jobs:
       rm GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
       echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
       sudo add-apt-repository -y "deb https://apt.repos.intel.com/oneapi all main"
-      sudo add-apt-repository -y ppa:intel-opencl/intel-opencl
       sudo apt-get update
       sudo apt-get install              \
           intel-oneapi-common-vars      \
@@ -19,12 +18,20 @@ jobs:
           intel-oneapi-dpcpp-compiler   \
           intel-oneapi-dev-utilities    \
           intel-oneapi-libdpstd-devel   \
-          cmake                         \
-          libze-loader                  \
-          libze-intel-gpu
+          cmake
       sudo bash -c 'echo libintelocl.so > /etc/OpenCL/vendors/intel-cpu.icd'
       sudo mv -f /opt/intel/inteloneapi/compiler/latest/linux/lib/oclfpga /opt/intel/inteloneapi/compiler/latest/linux/lib/oclfpga_
     displayName: 'apt-get'
+  - script: |
+    git clone https://github.com/oneapi-src/level-zero.git
+    cd level-zero
+    mkdir build
+    cd build
+    cmake ..
+    cmake --build . --config Release
+    cmake --build . --config Release --target package
+    sudo cmake --build . --config Release --target install
+    displayName: Build L0 (Workaround for Beta06)
   - script: conda create -q -y -n CB python=3.7 conda-build conda-verify
     displayName: Create Anaconda environment
   - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,14 +23,14 @@ jobs:
       sudo mv -f /opt/intel/inteloneapi/compiler/latest/linux/lib/oclfpga /opt/intel/inteloneapi/compiler/latest/linux/lib/oclfpga_
     displayName: 'apt-get'
   - script: |
-    git clone https://github.com/oneapi-src/level-zero.git
-    cd level-zero
-    mkdir build
-    cd build
-    cmake ..
-    cmake --build . --config Release
-    cmake --build . --config Release --target package
-    sudo cmake --build . --config Release --target install
+      git clone https://github.com/oneapi-src/level-zero.git
+      cd level-zero
+      mkdir build
+      cd build
+      cmake ..
+      cmake --build . --config Release
+      cmake --build . --config Release --target package
+      sudo cmake --build . --config Release --target install
     displayName: Build L0 (Workaround for Beta06)
   - script: conda create -q -y -n CB python=3.7 conda-build conda-verify
     displayName: Create Anaconda environment

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,7 +21,7 @@ jobs:
           cmake                         \
           intel-opencl-icd
       sudo bash -c 'echo libintelocl.so > /etc/OpenCL/vendors/intel-cpu.icd'
-      sudo mv /opt/intel/inteloneapi/compiler/latest/linux/lib/oclfpga /opt/intel/inteloneapi/compiler/latest/linux/lib/oclfpga_
+      sudo mv -f /opt/intel/inteloneapi/compiler/latest/linux/lib/oclfpga /opt/intel/inteloneapi/compiler/latest/linux/lib/oclfpga_
     displayName: 'apt-get'
   - script: conda create -q -y -n CB python=3.7 conda-build conda-verify
     displayName: Create Anaconda environment

--- a/setup.py
+++ b/setup.py
@@ -138,7 +138,9 @@ def getpyexts():
     if IS_WIN:
         libraries_plat = ['daal_core_dll']
     else:
-        libraries_plat = ['daal_core', 'daal_thread', 'ze_loader']
+        libraries_plat = ['daal_core', 'daal_thread']
+        if dpcpp:
+            libraries_plat = ['daal_core', 'daal_thread', 'ze_loader']
 
     if IS_MAC:
         ela.append('-stdlib=libc++')

--- a/setup.py
+++ b/setup.py
@@ -138,9 +138,10 @@ def getpyexts():
     if IS_WIN:
         libraries_plat = ['daal_core_dll']
     else:
-        libraries_plat = ['daal_core', 'daal_thread']
         if dpcpp:
             libraries_plat = ['daal_core', 'daal_thread', 'ze_loader']
+        else:
+            libraries_plat = ['daal_core', 'daal_thread']
 
     if IS_MAC:
         ela.append('-stdlib=libc++')

--- a/setup.py
+++ b/setup.py
@@ -138,7 +138,7 @@ def getpyexts():
     if IS_WIN:
         libraries_plat = ['daal_core_dll']
     else:
-        libraries_plat = ['daal_core', 'daal_thread']
+        libraries_plat = ['daal_core', 'daal_thread', 'ze_loader']
 
     if IS_MAC:
         ela.append('-stdlib=libc++')

--- a/src/oneapi/oneapi.h
+++ b/src/oneapi/oneapi.h
@@ -48,8 +48,7 @@ public:
         else if(dev == "host") m_ctxt = new daal::services::SyclExecutionContext(cl::sycl::queue(cl::sycl::host_selector()));
         else
         {
-            std::cout << "Unknown device \'" << dev << "\' was specified.\nFalling back to default device.\n";
-            m_ctxt = new daal::services::SyclExecutionContext(cl::sycl::queue(cl::sycl::default_selector()));
+            throw std::runtime_error(std::string("Device is not supported: ") + dev); 
         }
         daal::services::Environment::getInstance()->setDefaultExecutionContext(*m_ctxt);
     }


### PR DESCRIPTION
This change
fixes #171 
fixes public CI for oneDAL Beta06 release - this workaround should be removed with next oneDAL release