### PR TITLE
Replace deprecated parameter goalFunction to objectiveFunction

### DIFF
--- a/src/dist_kmeans.h
+++ b/src/dist_kmeans.h
@@ -22,7 +22,7 @@
 #include "map_reduce_tree.h"
 
 namespace dist_custom {
-    
+
 template<typename fptype, daal::algorithms::kmeans::Method method>
 class dist_custom< kmeans_manager< fptype, method > >
 {
@@ -60,7 +60,7 @@ public:
                 fres = algo.run_step2Master__final(std::vector< daal::algorithms::kmeans::PartialResultPtr >(1, pres));
                 // now check if we convered/reached max_iter
                 if(iter < algo._maxIterations) {
-                    double new_goal = fres->get(daal::algorithms::kmeans::goalFunction)->daal::data_management::NumericTable::template getValue<double>(0, 0);
+                    double new_goal = fres->get(daal::algorithms::kmeans::objectiveFunction)->daal::data_management::NumericTable::template getValue<double>(0, 0);
                     if(std::abs(goal - new_goal) > accuracyThreshold) {
                         centroids = fres->get(daal::algorithms::kmeans::centroids);
                         goal = new_goal;


### PR DESCRIPTION
DAAL deprecated parameter `goalFunction` ~3 years ago. Instead parameter `goalFunciton` need use `objectiveFunction`. See more details [here](https://software.intel.com/content/www/us/en/develop/documentation/daal-programming-guide/top/algorithms/analysis/k-means-clustering/computation/batch-processing-6.html) 
In latest version DAAL we remove parameter `goalFunction` from interfaces.