### PR TITLE
Fix tests fails with new Scikit-Learn 0.23.1

### DIFF
--- a/daal4py/sklearn/linear_model/_logistic_path_0_22.py
+++ b/daal4py/sklearn/linear_model/_logistic_path_0_22.py
@@ -696,7 +696,7 @@ def __logistic_regression_path(X, y, pos_class=None, Cs=10, fit_intercept=True,
     # the class_weights are assigned after masking the labels with a OvR.
     le = LabelEncoder()
     if isinstance(class_weight, dict) or multi_class == 'multinomial':
-        class_weight_ = compute_class_weight(class_weight, classes, y)
+        class_weight_ = compute_class_weight(class_weight, classes=classes, y=y)
         sample_weight *= class_weight_[le.fit_transform(y)]
 
     # For doing a ovr, we need to mask the labels first. for the
@@ -710,8 +710,8 @@ def __logistic_regression_path(X, y, pos_class=None, Cs=10, fit_intercept=True,
         # for compute_class_weight
 
         if class_weight == "balanced":
-            class_weight_ = compute_class_weight(class_weight, mask_classes,
-                                                 y_bin)
+            class_weight_ = compute_class_weight(class_weight, classes=mask_classes,
+                                                 y=y_bin)
             sample_weight *= class_weight_[le.fit_transform(y_bin)]
 
         daal_ready = daal_ready and (default_weights or np.allclose(sample_weight, np.ones_like(sample_weight)))


### PR DESCRIPTION
For now I made changes only in branch of code for latest version of Scikit-Learn.
But I think that our work with Logistic Regression is too complicated. We have the branching on init stage in
https://github.com/IntelPython/daal4py/blob/master/daal4py/sklearn/linear_model/logistic_path.py
like
```
if LooseVersion(sklearn_version) >= LooseVersion("0.22"):
    from ._logistic_path_0_22 import *
else:
    from ._logistic_path_0_21 import *
```
and in files ``_logistic_path_*.py`` themselves.
Please help me clarify that it is really necessary and advice how to simplify it.