### PR TITLE
Removing pandas conversion in Linear Regression

### DIFF
--- a/daal4py/sklearn/_utils.py
+++ b/daal4py/sklearn/_utils.py
@@ -76,3 +76,21 @@ def is_in_sycl_ctxt():
         return is_in_ctx()
     except ModuleNotFoundError:
         return False
+
+def is_DataFrame(X):
+    try:
+        from pandas import DataFrame
+        return isinstance(X, DataFrame)
+    except ImportError:
+        return False
+
+def get_dtype(X, is_dataframe):
+    try:
+        from pandas.core.dtypes.cast import find_common_type
+        return find_common_type(X.dtypes) if is_dataframe else X.dtype
+    except ImportError:
+        return getattr(X, "dtype", None)
+
+def get_number_of_types(dataframe):
+    dtypes = getattr(dataframe, "dtypes", None)
+    return 1 if dtypes is None else len(set(dtypes))

--- a/daal4py/sklearn/_utils.py
+++ b/daal4py/sklearn/_utils.py
@@ -84,10 +84,10 @@ def is_DataFrame(X):
     except ImportError:
         return False
 
-def get_dtype(X, is_dataframe):
+def get_dtype(X):
     try:
         from pandas.core.dtypes.cast import find_common_type
-        return find_common_type(X.dtypes) if is_dataframe else X.dtype
+        return find_common_type(X.dtypes) if is_DataFrame(X) else X.dtype
     except ImportError:
         return getattr(X, "dtype", None)
 

--- a/daal4py/sklearn/_utils.py
+++ b/daal4py/sklearn/_utils.py
@@ -38,14 +38,26 @@ def daal_check_version(trad_target, dpcpp_target):
         result = result and daal_link_version >= trad_target
     return result
 
-def getFPType(X):
-    dt = getattr(X, 'dtype', None)
+def parse_dtype(dt):
     if dt == np.double:
         return "double"
     elif dt == np.single:
         return "float"
     else:
         raise ValueError("Input array has unexpected dtype = {}".format(dt))
+
+def getFPType(X):
+    try:
+        from pandas import DataFrame
+        from pandas.core.dtypes.cast import find_common_type
+        if isinstance(X, DataFrame):
+            dt = find_common_type(X.dtypes)
+            return parse_dtype(dt)
+    except ImportError:
+        pass
+
+    dt = getattr(X, 'dtype', None)
+    return parse_dtype(dt)
 
 def make2d(X):
     if np.isscalar(X):

--- a/daal4py/sklearn/linear_model/_linear_0_21.py
+++ b/daal4py/sklearn/linear_model/_linear_0_21.py
@@ -120,7 +120,7 @@ def fit(self, X, y, sample_weight=None):
     X, y = _daal_check_X_y(X, y, accept_sparse=['csr', 'csc', 'coo'],
                            y_numeric=True, multi_output=True)
 
-    dtype = get_dtype(X, is_DataFrame(X))
+    dtype = get_dtype(X)
 
     self.sample_weight_ = sample_weight
     self.fit_shape_good_for_daal_ = bool(X.shape[0] > X.shape[1] + int(self.fit_intercept))
@@ -186,7 +186,7 @@ def predict(self, X):
     is_df = is_DataFrame(X)
     X = np.asarray(X) if not sp.issparse(X) and not is_df else X
     good_shape_for_daal = True if X.ndim <= 1 else True if X.shape[0] > X.shape[1] else False
-    dtype = get_dtype(X, is_df)
+    dtype = get_dtype(X)
 
     if (sp.issparse(X) or
             not hasattr(self, 'daal_model_') or

--- a/daal4py/sklearn/linear_model/_linear_0_21.py
+++ b/daal4py/sklearn/linear_model/_linear_0_21.py
@@ -19,8 +19,9 @@ import numpy as np
 from scipy import sparse as sp
 from scipy import linalg
 
-from sklearn.utils import check_array, check_X_y, deprecated, as_float_array
+from sklearn.utils import deprecated, as_float_array
 from sklearn.linear_model.base import _rescale_data
+from ..utils.validation import _daal_check_array, _daal_check_X_y
 
 from sklearn.utils.fixes import sparse_lsqr
 from sklearn.linear_model import LinearRegression as LinearRegression_original
@@ -115,14 +116,22 @@ def fit(self, X, y, sample_weight=None):
     """
 
     n_jobs_ = self.n_jobs
-    X, y = check_X_y(X, y, accept_sparse=['csr', 'csc', 'coo'],
-                     y_numeric=True, multi_output=True)
+    X, y = _daal_check_X_y(X, y, accept_sparse=['csr', 'csc', 'coo'],
+                           y_numeric=True, multi_output=True)
+
+    try:
+        from pandas import DataFrame
+        from pandas.core.dtypes.cast import find_common_type
+        dtype = find_common_type(X.dtypes) if isinstance(X, DataFrame) else X.dtype
+    except ImportError:
+        dtype = X.dtype
 
     self.sample_weight_ = sample_weight
     self.fit_shape_good_for_daal_ = bool(X.shape[0] > X.shape[1] + int(self.fit_intercept))
+
     if (self.fit_shape_good_for_daal_ and
             not sp.issparse(X) and
-            (X.dtype == np.float64 or X.dtype == np.float32) and
+            (dtype == np.float64 or dtype == np.float32) and
             sample_weight is None):
         logging.info("sklearn.linar_model.LinearRegression.fit: " + method_uses_daal)
         res = _daal4py_fit(self, X, y)
@@ -178,20 +187,32 @@ def predict(self, X):
     C : array, shape = (n_samples,)
         Returns predicted values.
     """
-    X = np.asarray(X) if not sp.issparse(X) else X
+    try:
+        from pandas import DataFrame
+        is_DataFrame = isinstance(X, DataFrame)
+    except ImportError:
+        is_DataFrame = False
+
+    X = np.asarray(X) if not sp.issparse(X) and not is_DataFrame else X
     good_shape_for_daal = True if X.ndim <= 1 else True if X.shape[0] > X.shape[1] else False
+
+    try:
+        from pandas.core.dtypes.cast import find_common_type
+        dtype = find_common_type(X.dtypes) if is_DataFrame else X.dtype
+    except ImportError:
+        dtype = X.dtype
 
     if (sp.issparse(X) or
             not hasattr(self, 'daal_model_') or
             not self.fit_shape_good_for_daal_ or
             not good_shape_for_daal or
-            not (X.dtype == np.float64 or X.dtype == np.float32) or
+            not (dtype == np.float64 or dtype == np.float32) or
             (hasattr(self, 'sample_weight_') and self.sample_weight_ is not None)):
         logging.info("sklearn.linar_model.LinearRegression.predict: " + method_uses_sklearn)
         return self._decision_function(X)
     else:
         logging.info("sklearn.linar_model.LinearRegression.predict: " + method_uses_daal)
-        X = check_array(X)
+        X = _daal_check_array(X)
         return _daal4py_predict(self, X)
 
 

--- a/daal4py/sklearn/linear_model/_linear_0_22.py
+++ b/daal4py/sklearn/linear_model/_linear_0_22.py
@@ -19,8 +19,9 @@ import numpy as np
 from scipy import sparse as sp
 from scipy import linalg
 
-from sklearn.utils import check_array, check_X_y, deprecated, as_float_array
+from sklearn.utils import deprecated, as_float_array
 from sklearn.linear_model._base import _rescale_data
+from ..utils.validation import _daal_check_array, _daal_check_X_y
 
 from sklearn.utils.fixes import sparse_lsqr
 from sklearn.utils.validation import _check_sample_weight
@@ -122,18 +123,26 @@ def fit(self, X, y, sample_weight=None):
     """
 
     n_jobs_ = self.n_jobs
-    X, y = check_X_y(X, y, accept_sparse=['csr', 'csc', 'coo'],
-                     y_numeric=True, multi_output=True)
+    X, y = _daal_check_X_y(X, y, accept_sparse=['csr', 'csc', 'coo'],
+                           y_numeric=True, multi_output=True)
+
+    try:
+        from pandas import DataFrame
+        from pandas.core.dtypes.cast import find_common_type
+        dtype = find_common_type(X.dtypes) if isinstance(X, DataFrame) else X.dtype
+    except ImportError:
+        dtype = X.dtype
 
     if sample_weight is not None:
         sample_weight = _check_sample_weight(sample_weight, X,
-                                             dtype=X.dtype)
+                                             dtype=dtype)
 
     self.sample_weight_ = sample_weight
     self.fit_shape_good_for_daal_ = bool(X.shape[0] > X.shape[1] + int(self.fit_intercept))
+
     if (self.fit_shape_good_for_daal_ and
             not sp.issparse(X) and
-            (X.dtype == np.float64 or X.dtype == np.float32) and
+            (dtype == np.float64 or dtype == np.float32) and
             sample_weight is None):
         logging.info("sklearn.linar_model.LinearRegression.fit: " + method_uses_daal)
         res = _daal4py_fit(self, X, y)
@@ -203,20 +212,32 @@ def predict(self, X):
     C : array, shape = (n_samples,)
         Returns predicted values.
     """
-    X = np.asarray(X) if not sp.issparse(X) else X
+    try:
+        from pandas import DataFrame
+        is_DataFrame = isinstance(X, DataFrame)
+    except ImportError:
+        is_DataFrame = False
+
+    X = np.asarray(X) if not sp.issparse(X) and not is_DataFrame else X
     good_shape_for_daal = True if X.ndim <= 1 else True if X.shape[0] > X.shape[1] else False
+
+    try:
+        from pandas.core.dtypes.cast import find_common_type
+        dtype = find_common_type(X.dtypes) if is_DataFrame else X.dtype
+    except ImportError:
+        dtype = X.dtype
 
     if (sp.issparse(X) or
             not hasattr(self, 'daal_model_') or
             not self.fit_shape_good_for_daal_ or
             not good_shape_for_daal or
-            not (X.dtype == np.float64 or X.dtype == np.float32) or
+            not (dtype == np.float64 or dtype == np.float32) or
             (hasattr(self, 'sample_weight_') and self.sample_weight_ is not None)):
         logging.info("sklearn.linar_model.LinearRegression.predict: " + method_uses_sklearn)
         return self._decision_function(X)
     else:
         logging.info("sklearn.linar_model.LinearRegression.predict: " + method_uses_daal)
-        X = check_array(X)
+        X = _daal_check_array(X)
         return _daal4py_predict(self, X)
 
 

--- a/daal4py/sklearn/linear_model/_linear_0_22.py
+++ b/daal4py/sklearn/linear_model/_linear_0_22.py
@@ -35,7 +35,8 @@ except ImportError:
 
 import daal4py
 from .._utils import (make2d, getFPType, method_uses_sklearn, \
-                    method_uses_daal, method_uses_sklearn_arter_daal)
+                    method_uses_daal, method_uses_sklearn_arter_daal,
+                    is_DataFrame, get_dtype)
 import logging
 
 def _daal4py_fit(self, X, y_):
@@ -126,12 +127,7 @@ def fit(self, X, y, sample_weight=None):
     X, y = _daal_check_X_y(X, y, accept_sparse=['csr', 'csc', 'coo'],
                            y_numeric=True, multi_output=True)
 
-    try:
-        from pandas import DataFrame
-        from pandas.core.dtypes.cast import find_common_type
-        dtype = find_common_type(X.dtypes) if isinstance(X, DataFrame) else X.dtype
-    except ImportError:
-        dtype = X.dtype
+    dtype = get_dtype(X, is_DataFrame(X))
 
     if sample_weight is not None:
         sample_weight = _check_sample_weight(sample_weight, X,
@@ -212,20 +208,10 @@ def predict(self, X):
     C : array, shape = (n_samples,)
         Returns predicted values.
     """
-    try:
-        from pandas import DataFrame
-        is_DataFrame = isinstance(X, DataFrame)
-    except ImportError:
-        is_DataFrame = False
-
-    X = np.asarray(X) if not sp.issparse(X) and not is_DataFrame else X
+    is_df = is_DataFrame(X)
+    X = np.asarray(X) if not sp.issparse(X) and not is_df else X
     good_shape_for_daal = True if X.ndim <= 1 else True if X.shape[0] > X.shape[1] else False
-
-    try:
-        from pandas.core.dtypes.cast import find_common_type
-        dtype = find_common_type(X.dtypes) if is_DataFrame else X.dtype
-    except ImportError:
-        dtype = X.dtype
+    dtype = get_dtype(X, is_df)
 
     if (sp.issparse(X) or
             not hasattr(self, 'daal_model_') or

--- a/daal4py/sklearn/linear_model/_linear_0_22.py
+++ b/daal4py/sklearn/linear_model/_linear_0_22.py
@@ -127,7 +127,7 @@ def fit(self, X, y, sample_weight=None):
     X, y = _daal_check_X_y(X, y, accept_sparse=['csr', 'csc', 'coo'],
                            y_numeric=True, multi_output=True)
 
-    dtype = get_dtype(X, is_DataFrame(X))
+    dtype = get_dtype(X)
 
     if sample_weight is not None:
         sample_weight = _check_sample_weight(sample_weight, X,
@@ -211,7 +211,7 @@ def predict(self, X):
     is_df = is_DataFrame(X)
     X = np.asarray(X) if not sp.issparse(X) and not is_df else X
     good_shape_for_daal = True if X.ndim <= 1 else True if X.shape[0] > X.shape[1] else False
-    dtype = get_dtype(X, is_df)
+    dtype = get_dtype(X)
 
     if (sp.issparse(X) or
             not hasattr(self, 'daal_model_') or

--- a/daal4py/sklearn/linear_model/_linear_0_23.py
+++ b/daal4py/sklearn/linear_model/_linear_0_23.py
@@ -128,7 +128,7 @@ def fit(self, X, y, sample_weight=None):
     X, y = _daal_validate_data(self, X, y, accept_sparse=['csr', 'csc', 'coo'],
                                y_numeric=True, multi_output=True)
 
-    dtype = get_dtype(X, is_DataFrame(X))
+    dtype = get_dtype(X)
 
     if sample_weight is not None:
         sample_weight = _check_sample_weight(sample_weight, X,
@@ -212,7 +212,7 @@ def predict(self, X):
     is_df = is_DataFrame(X)
     X = np.asarray(X) if not sp.issparse(X) and not is_df else X
     good_shape_for_daal = True if X.ndim <= 1 else True if X.shape[0] > X.shape[1] else False
-    dtype = get_dtype(X, is_df)
+    dtype = get_dtype(X)
 
     if (sp.issparse(X) or
             not hasattr(self, 'daal_model_') or

--- a/daal4py/sklearn/linear_model/_linear_0_23.py
+++ b/daal4py/sklearn/linear_model/_linear_0_23.py
@@ -36,7 +36,8 @@ except ImportError:
 
 import daal4py
 from .._utils import (make2d, getFPType, method_uses_sklearn, \
-                    method_uses_daal, method_uses_sklearn_arter_daal)
+                    method_uses_daal, method_uses_sklearn_arter_daal,
+                    is_DataFrame, get_dtype)
 import logging
 
 def _daal4py_fit(self, X, y_):
@@ -127,12 +128,7 @@ def fit(self, X, y, sample_weight=None):
     X, y = _daal_validate_data(self, X, y, accept_sparse=['csr', 'csc', 'coo'],
                                y_numeric=True, multi_output=True)
 
-    try:
-        from pandas import DataFrame
-        from pandas.core.dtypes.cast import find_common_type
-        dtype = find_common_type(X.dtypes) if isinstance(X, DataFrame) else X.dtype
-    except ImportError:
-        dtype = X.dtype
+    dtype = get_dtype(X, is_DataFrame(X))
 
     if sample_weight is not None:
         sample_weight = _check_sample_weight(sample_weight, X,
@@ -213,20 +209,10 @@ def predict(self, X):
     C : array, shape = (n_samples,)
         Returns predicted values.
     """
-    try:
-        from pandas import DataFrame
-        is_DataFrame = isinstance(X, DataFrame)
-    except ImportError:
-        is_DataFrame = False
-
-    X = np.asarray(X) if not sp.issparse(X) and not is_DataFrame else X
+    is_df = is_DataFrame(X)
+    X = np.asarray(X) if not sp.issparse(X) and not is_df else X
     good_shape_for_daal = True if X.ndim <= 1 else True if X.shape[0] > X.shape[1] else False
-
-    try:
-        from pandas.core.dtypes.cast import find_common_type
-        dtype = find_common_type(X.dtypes) if is_DataFrame else X.dtype
-    except ImportError:
-        dtype = X.dtype
+    dtype = get_dtype(X, is_df)
 
     if (sp.issparse(X) or
             not hasattr(self, 'daal_model_') or

--- a/daal4py/sklearn/linear_model/tests/test_linear.py
+++ b/daal4py/sklearn/linear_model/tests/test_linear.py
@@ -1,6 +1,6 @@
 #
 #*******************************************************************************
-# Copyright 2014-2020 Intel Corporation
+# Copyright 2020 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/daal4py/sklearn/linear_model/tests/test_linear.py
+++ b/daal4py/sklearn/linear_model/tests/test_linear.py
@@ -1,13 +1,29 @@
+#
+#*******************************************************************************
+# Copyright 2014-2020 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#******************************************************************************/
+
 import pytest
 import numpy as np
 import pandas as pd
-from sklearn.utils._testing import assert_array_equal
+from sklearn.utils._testing import assert_array_almost_equal
 from sklearn.linear_model import LinearRegression
 from sklearn.datasets import make_regression
-from daal4py.sklearn import patch_sklearn, unpatch_sklearn
 
 
-def make_dataset(n_samples, n_features, kind=np.array, random_state=0):
+def make_dataset(n_samples, n_features, kind=np.array, random_state=0, types=None):
     try:
         from pandas import DataFrame
         if kind not in (list, np.array, DataFrame):
@@ -24,12 +40,23 @@ def make_dataset(n_samples, n_features, kind=np.array, random_state=0):
             x[i] = list(row)
         y = list(y)
 
+        if types:
+            n_types = len(types)
+            for i, row in enumerate(x):
+                for j, cell in enumerate(row):
+                    x[i][j] = types[j%n_types](cell)
+
     try:
         from pandas import DataFrame
 
         if kind == DataFrame:
             x = DataFrame(data=x, index=None, columns=None)
             y = DataFrame(y)
+
+            if types:
+                n_types = len(types)
+                dir_dtypes = {col: types[i%n_types] for i, col in enumerate(x.columns)}
+                x = x.astype(dir_dtypes)
     except ImportError:
         pass
 
@@ -49,32 +76,96 @@ def test_linear_array_vs_dataframe_homogen():
     array_reg.fit(x_train, y_train)
 
     df_reg = LinearRegression()
-    df_reg.fit(x_train, y_train)
+    df_reg.fit(df_x_train, df_y_train)
 
-    assert_array_equal(array_reg.coef_, df_reg.coef_)
-    assert_array_equal(array_reg.intercept_, df_reg.intercept_)
-    assert_array_equal(array_reg.predict(x_test), df_reg.predict(x_test))
+    assert_array_almost_equal(array_reg.coef_.reshape((-1, 1)), df_reg.coef_.reshape((-1, 1)))
+    assert_array_almost_equal(array_reg.intercept_, df_reg.intercept_)
+    assert_array_almost_equal(array_reg.predict(x_test).reshape((-1, 1)), df_reg.predict(df_x_test).reshape((-1, 1)))
 
 
 def test_linear_array_vs_dataframe_heterogen():
     pd = pytest.importorskip('pandas')
 
+    types = (np.float64, np.float32)
+
     x_train, y_train = make_dataset(100, 20)
     x_test, _ = make_dataset(100, 20, random_state=1)
 
-    df_x_train, df_y_train = make_dataset(100, 20, pd.DataFrame)
-    df_x_test, _ = make_dataset(100, 20, pd.DataFrame, random_state=1)
-
-    dir_dtypes = {col: 'float64' if i % 2 == 0 else 'float32' for i, col in enumerate(df_x_train.columns)}
-    df_x_train = df_x_train.astype(dir_dtypes)
-    df_x_test = df_x_test.astype(dir_dtypes)
+    df_x_train, df_y_train = make_dataset(100, 20, pd.DataFrame, types=types)
+    df_x_test, _ = make_dataset(100, 20, pd.DataFrame, random_state=1, types=types)
 
     array_reg = LinearRegression()
     array_reg.fit(x_train, y_train)
 
     df_reg = LinearRegression()
-    df_reg.fit(x_train, y_train)
+    df_reg.fit(df_x_train, df_y_train)
 
-    assert_array_equal(array_reg.coef_, df_reg.coef_)
-    assert_array_equal(array_reg.intercept_, df_reg.intercept_)
-    assert_array_equal(array_reg.predict(x_test), df_reg.predict(x_test))
+    assert_array_almost_equal(array_reg.coef_.reshape((-1, 1)), df_reg.coef_.reshape((-1, 1)))
+    assert_array_almost_equal(array_reg.intercept_, df_reg.intercept_)
+    assert_array_almost_equal(array_reg.predict(x_test).reshape((-1, 1)), df_reg.predict(df_x_test).reshape((-1, 1)), decimal=5)
+
+
+def test_linear_array_vs_dataframe_heterogen_double_float():
+    pd = pytest.importorskip('pandas')
+
+    types = (np.float64, np.float32)
+
+    x_train, y_train = make_dataset(100, 20, list, types=types)
+    x_test, _ = make_dataset(100, 20, list, random_state=1, types=types)
+
+    df_x_train, df_y_train = make_dataset(100, 20, pd.DataFrame, types=types)
+    df_x_test, _ = make_dataset(100, 20, pd.DataFrame, random_state=1, types=types)
+
+    array_reg = LinearRegression()
+    array_reg.fit(x_train, y_train)
+
+    df_reg = LinearRegression()
+    df_reg.fit(df_x_train, df_y_train)
+
+    assert_array_almost_equal(array_reg.coef_.reshape((-1, 1)), df_reg.coef_.reshape((-1, 1)))
+    assert_array_almost_equal(array_reg.intercept_, df_reg.intercept_)
+    assert_array_almost_equal(array_reg.predict(x_test).reshape((-1, 1)), df_reg.predict(df_x_test).reshape((-1, 1)))
+
+
+def test_linear_array_vs_dataframe_heterogen_double_int():
+    pd = pytest.importorskip('pandas')
+
+    types = (np.float64, np.int32)
+
+    x_train, y_train = make_dataset(100, 20, list, types=types)
+    x_test, _ = make_dataset(100, 20, list, random_state=1, types=types)
+
+    df_x_train, df_y_train = make_dataset(100, 20, pd.DataFrame, types=types)
+    df_x_test, _ = make_dataset(100, 20, pd.DataFrame, random_state=1, types=types)
+
+    array_reg = LinearRegression()
+    array_reg.fit(x_train, y_train)
+
+    df_reg = LinearRegression()
+    df_reg.fit(df_x_train, df_y_train)
+
+    assert_array_almost_equal(array_reg.coef_.reshape((-1, 1)), df_reg.coef_.reshape((-1, 1)))
+    assert_array_almost_equal(array_reg.intercept_, df_reg.intercept_)
+    assert_array_almost_equal(array_reg.predict(x_test).reshape((-1, 1)), df_reg.predict(df_x_test).reshape((-1, 1)))
+
+
+def test_linear_array_vs_dataframe_heterogen_float_int():
+    pd = pytest.importorskip('pandas')
+
+    types = (np.float32, np.int32)
+
+    x_train, y_train = make_dataset(100, 20, list, types=types)
+    x_test, _ = make_dataset(100, 20, list, random_state=1, types=types)
+
+    df_x_train, df_y_train = make_dataset(100, 20, pd.DataFrame, types=types)
+    df_x_test, _ = make_dataset(100, 20, pd.DataFrame, random_state=1, types=types)
+
+    array_reg = LinearRegression()
+    array_reg.fit(x_train, y_train)
+
+    df_reg = LinearRegression()
+    df_reg.fit(df_x_train, df_y_train)
+
+    assert_array_almost_equal(array_reg.coef_.reshape((-1, 1)), df_reg.coef_.reshape((-1, 1)))
+    assert_array_almost_equal(array_reg.intercept_, df_reg.intercept_)
+    assert_array_almost_equal(array_reg.predict(x_test).reshape((-1, 1)), df_reg.predict(df_x_test).reshape((-1, 1)))

--- a/daal4py/sklearn/linear_model/tests/test_linear.py
+++ b/daal4py/sklearn/linear_model/tests/test_linear.py
@@ -1,0 +1,80 @@
+import pytest
+import numpy as np
+import pandas as pd
+from sklearn.utils._testing import assert_array_equal
+from sklearn.linear_model import LinearRegression
+from sklearn.datasets import make_regression
+from daal4py.sklearn import patch_sklearn, unpatch_sklearn
+
+
+def make_dataset(n_samples, n_features, kind=np.array, random_state=0):
+    try:
+        from pandas import DataFrame
+        if kind not in (list, np.array, DataFrame):
+            kind = np.array
+    except ImportError:
+        if kind not in (list, np.array):
+            kind = np.array
+
+    x, y = make_regression(n_samples, n_features, random_state=random_state)
+
+    if kind == list:
+        x = list(x)
+        for i, row in enumerate(x):
+            x[i] = list(row)
+        y = list(y)
+
+    try:
+        from pandas import DataFrame
+
+        if kind == DataFrame:
+            x = DataFrame(data=x, index=None, columns=None)
+            y = DataFrame(y)
+    except ImportError:
+        pass
+
+    return x, y
+
+
+def test_linear_array_vs_dataframe_homogen():
+    pd = pytest.importorskip('pandas')
+
+    x_train, y_train = make_dataset(100, 20)
+    x_test, _ = make_dataset(100, 20, random_state=1)
+
+    df_x_train, df_y_train = make_dataset(100, 20, pd.DataFrame)
+    df_x_test, _ = make_dataset(100, 20, pd.DataFrame, random_state=1)
+
+    array_reg = LinearRegression()
+    array_reg.fit(x_train, y_train)
+
+    df_reg = LinearRegression()
+    df_reg.fit(x_train, y_train)
+
+    assert_array_equal(array_reg.coef_, df_reg.coef_)
+    assert_array_equal(array_reg.intercept_, df_reg.intercept_)
+    assert_array_equal(array_reg.predict(x_test), df_reg.predict(x_test))
+
+
+def test_linear_array_vs_dataframe_heterogen():
+    pd = pytest.importorskip('pandas')
+
+    x_train, y_train = make_dataset(100, 20)
+    x_test, _ = make_dataset(100, 20, random_state=1)
+
+    df_x_train, df_y_train = make_dataset(100, 20, pd.DataFrame)
+    df_x_test, _ = make_dataset(100, 20, pd.DataFrame, random_state=1)
+
+    dir_dtypes = {col: 'float64' if i % 2 == 0 else 'float32' for i, col in enumerate(df_x_train.columns)}
+    df_x_train = df_x_train.astype(dir_dtypes)
+    df_x_test = df_x_test.astype(dir_dtypes)
+
+    array_reg = LinearRegression()
+    array_reg.fit(x_train, y_train)
+
+    df_reg = LinearRegression()
+    df_reg.fit(x_train, y_train)
+
+    assert_array_equal(array_reg.coef_, df_reg.coef_)
+    assert_array_equal(array_reg.intercept_, df_reg.intercept_)
+    assert_array_equal(array_reg.predict(x_test), df_reg.predict(x_test))

--- a/daal4py/sklearn/utils/__init__.py
+++ b/daal4py/sklearn/utils/__init__.py
@@ -17,4 +17,5 @@
 
 from .validation import _daal_assert_all_finite
 
-__all__ = ['_daal_assert_all_finite']
+__all__ = ['_daal_assert_all_finite', '_daal_check_array', '_daal_check_X_y',
+           '_daal_validate_data']

--- a/daal4py/sklearn/utils/base.py
+++ b/daal4py/sklearn/utils/base.py
@@ -1,0 +1,57 @@
+from .validation import _daal_check_array, _daal_check_X_y
+
+def _daal_validate_data(self, X, y=None, reset=True,
+                   validate_separately=False, **check_params):
+    """Validate input data and set or check the `n_features_in_` attribute.
+
+    Parameters
+    ----------
+    X : {array-like, sparse matrix, dataframe} of shape \
+            (n_samples, n_features)
+        The input samples.
+    y : array-like of shape (n_samples,), default=None
+        The targets. If None, `check_array` is called on `X` and
+        `check_X_y` is called otherwise.
+    reset : bool, default=True
+        Whether to reset the `n_features_in_` attribute.
+        If False, the input will be checked for consistency with data
+        provided when reset was last True.
+    validate_separately : False or tuple of dicts, default=False
+        Only used if y is not None.
+        If False, call validate_X_y(). Else, it must be a tuple of kwargs
+        to be used for calling check_array() on X and y respectively.
+    **check_params : kwargs
+        Parameters passed to :func:`sklearn.utils.check_array` or
+        :func:`sklearn.utils.check_X_y`. Ignored if validate_separately
+        is not False.
+
+    Returns
+    -------
+    out : {ndarray, sparse matrix} or tuple of these
+        The validated input. A tuple is returned if `y` is not None.
+    """
+
+    if y is None:
+        if self._get_tags()['requires_y']:
+            raise ValueError(
+                f"This {self.__class__.__name__} estimator "
+                f"requires y to be passed, but the target y is None."
+            )
+        X = _daal_check_array(X, **check_params)
+        out = X
+    else:
+        if validate_separately:
+            # We need this because some estimators validate X and y
+            # separately, and in general, separately calling check_array()
+            # on X and y isn't equivalent to just calling check_X_y()
+            # :(
+            check_X_params, check_y_params = validate_separately
+            X = _daal_check_array(X, **check_X_params)
+            y = _daal_check_array(y, **check_y_params)
+        else:
+            X, y = _daal_check_X_y(X, y, **check_params)
+        out = X, y
+
+    if check_params.get('ensure_2d', True):
+        self._check_n_features(X, reset=reset)
+    return out

--- a/daal4py/sklearn/utils/base.py
+++ b/daal4py/sklearn/utils/base.py
@@ -1,6 +1,6 @@
 #
 #*******************************************************************************
-# Copyright 2014-2020 Intel Corporation
+# Copyright 2020 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/daal4py/sklearn/utils/base.py
+++ b/daal4py/sklearn/utils/base.py
@@ -1,3 +1,20 @@
+#
+#*******************************************************************************
+# Copyright 2014-2020 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#******************************************************************************/
+
 from .validation import _daal_check_array, _daal_check_X_y
 
 def _daal_validate_data(self, X, y=None, reset=True,

--- a/daal4py/sklearn/utils/validation.py
+++ b/daal4py/sklearn/utils/validation.py
@@ -48,7 +48,7 @@ def _daal_assert_all_finite(X, allow_nan=False, msg_dtype=None):
     else:
         X = np.asanyarray(X)
 
-    dt = get_dtype(X, is_df)
+    dt = np.dtype(get_dtype(X, is_df))
     is_float = dt.kind in 'fc'
 
     msg_err = "Input contains {} or a value too large for {!r}."
@@ -217,9 +217,12 @@ def _daal_check_array(array, accept_sparse=False, *, accept_large_sparse=True,
 
     # a branch for heterogeneous pandas.DataFrame
     if is_DataFrame(array) and get_number_of_types(array) > 1:
-        return _pandas_check_array(array, array_orig, force_all_finite,
-                                   ensure_min_samples, ensure_min_features,
-                                   copy, context)
+        from pandas.api.types import is_sparse
+        if (hasattr(array, 'sparse') or
+                not array.dtypes.apply(is_sparse).any()):
+            return _pandas_check_array(array, array_orig, force_all_finite,
+                                       ensure_min_samples, ensure_min_features,
+                                       copy, context)
 
     # store whether originally we wanted numeric dtype
     dtype_numeric = isinstance(dtype, str) and dtype == "numeric"

--- a/daal4py/sklearn/utils/validation.py
+++ b/daal4py/sklearn/utils/validation.py
@@ -50,7 +50,7 @@ def _daal_assert_all_finite(X, allow_nan=False, msg_dtype=None):
         X = np.asanyarray(X)
         is_df = False
 
-    dt = np.dtype(get_dtype(X, is_df))
+    dt = np.dtype(get_dtype(X))
     is_float = dt.kind in 'fc'
 
     msg_err = "Input contains {} or a value too large for {!r}."

--- a/daal4py/sklearn/utils/validation.py
+++ b/daal4py/sklearn/utils/validation.py
@@ -19,6 +19,13 @@ import numpy as np
 import daal4py as d4p
 from sklearn import get_config as _get_config
 from sklearn.utils.fixes import _object_dtype_isnan
+import warnings
+from contextlib import suppress
+import scipy.sparse as sp
+from numpy.core.numeric import ComplexWarning
+from sklearn.utils.validation import _num_samples, _ensure_no_complex_data, \
+                                     _ensure_sparse_format, column_or_1d, \
+                                     check_consistent_length
 
 def _daal_assert_all_finite(X, allow_nan=False, msg_dtype=None):
     """Like assert_all_finite, but only for ndarray."""
@@ -62,3 +69,431 @@ def _daal_assert_all_finite(X, allow_nan=False, msg_dtype=None):
     elif X.dtype == np.dtype('object') and not allow_nan:
         if _object_dtype_isnan(X).any():
             raise ValueError("Input contains NaN")
+
+
+def _daal_check_array(array, accept_sparse=False, *, accept_large_sparse=True,
+                      dtype="numeric", order=None, copy=False, force_all_finite=True,
+                      ensure_2d=True, allow_nd=False, ensure_min_samples=1,
+                      ensure_min_features=1, estimator=None):
+
+    """Input validation on an array, list, sparse matrix or similar.
+
+    By default, the input is checked to be a non-empty 2D array containing
+    only finite values. If the dtype of the array is object, attempt
+    converting to float, raising on failure.
+
+    Parameters
+    ----------
+    array : object
+        Input object to check / convert.
+
+    accept_sparse : string, boolean or list/tuple of strings (default=False)
+        String[s] representing allowed sparse matrix formats, such as 'csc',
+        'csr', etc. If the input is sparse but not in the allowed format,
+        it will be converted to the first listed format. True allows the input
+        to be any format. False means that a sparse matrix input will
+        raise an error.
+
+    accept_large_sparse : bool (default=True)
+        If a CSR, CSC, COO or BSR sparse matrix is supplied and accepted by
+        accept_sparse, accept_large_sparse=False will cause it to be accepted
+        only if its indices are stored with a 32-bit dtype.
+
+        .. versionadded:: 0.20
+
+    dtype : string, type, list of types or None (default="numeric")
+        Data type of result. If None, the dtype of the input is preserved.
+        If "numeric", dtype is preserved unless array.dtype is object.
+        If dtype is a list of types, conversion on the first type is only
+        performed if the dtype of the input is not in the list.
+
+    order : 'F', 'C' or None (default=None)
+        Whether an array will be forced to be fortran or c-style.
+        When order is None (default), then if copy=False, nothing is ensured
+        about the memory layout of the output array; otherwise (copy=True)
+        the memory layout of the returned array is kept as close as possible
+        to the original array.
+
+    copy : boolean (default=False)
+        Whether a forced copy will be triggered. If copy=False, a copy might
+        be triggered by a conversion.
+
+    force_all_finite : boolean or 'allow-nan', (default=True)
+        Whether to raise an error on np.inf, np.nan, pd.NA in array. The
+        possibilities are:
+
+        - True: Force all values of array to be finite.
+        - False: accepts np.inf, np.nan, pd.NA in array.
+        - 'allow-nan': accepts only np.nan and pd.NA values in array. Values
+          cannot be infinite.
+
+        .. versionadded:: 0.20
+           ``force_all_finite`` accepts the string ``'allow-nan'``.
+
+        .. versionchanged:: 0.23
+           Accepts `pd.NA` and converts it into `np.nan`
+
+    ensure_2d : boolean (default=True)
+        Whether to raise a value error if array is not 2D.
+
+    allow_nd : boolean (default=False)
+        Whether to allow array.ndim > 2.
+
+    ensure_min_samples : int (default=1)
+        Make sure that the array has a minimum number of samples in its first
+        axis (rows for a 2D array). Setting to 0 disables this check.
+
+    ensure_min_features : int (default=1)
+        Make sure that the 2D array has some minimum number of features
+        (columns). The default value of 1 rejects empty datasets.
+        This check is only enforced when the input data has effectively 2
+        dimensions or is originally 1D and ``ensure_2d`` is True. Setting to 0
+        disables this check.
+
+    estimator : str or estimator instance (default=None)
+        If passed, include the name of the estimator in warning messages.
+
+    Returns
+    -------
+    array_converted : object
+        The converted and validated array.
+    """
+    if force_all_finite not in (True, False, 'allow-nan'):
+        raise ValueError('force_all_finite should be a bool or "allow-nan"'
+                         '. Got {!r} instead'.format(force_all_finite))
+
+    if estimator is not None:
+        if isinstance(estimator, str):
+            estimator_name = estimator
+        else:
+            estimator_name = estimator.__class__.__name__
+    else:
+        estimator_name = "Estimator"
+    context = " by %s" % estimator_name if estimator is not None else ""
+
+    array_orig = array
+
+    try:
+        from pandas import DataFrame, option_context
+        if isinstance(array, DataFrame) and force_all_finite != 'allow-nan':
+            if force_all_finite:
+                with option_context('mode.use_inf_as_na', True):
+                    if array.isna().any().any():
+                        raise ValueError('Input contains NaN or Inf')
+
+            if ensure_min_samples > 0:
+                n_samples = _num_samples(array)
+                if n_samples < ensure_min_samples:
+                    raise ValueError("Found array with %d sample(s) (shape=%s) while a"
+                                     " minimum of %d is required%s."
+                                     % (n_samples, array.shape, ensure_min_samples,
+                                        context))
+
+            if ensure_min_features > 0:
+                n_features = array.shape[1]
+                if n_features < ensure_min_features:
+                    raise ValueError("Found array with %d feature(s) (shape=%s) while"
+                                     " a minimum of %d is required%s."
+                                     % (n_features, array.shape, ensure_min_features,
+                                        context))
+
+            if copy and np.may_share_memory(array, array_orig):
+                array = array.copy()
+
+            return array
+    except ImportError:
+        pass
+
+    # store whether originally we wanted numeric dtype
+    dtype_numeric = isinstance(dtype, str) and dtype == "numeric"
+
+    dtype_orig = getattr(array, "dtype", None)
+    if not hasattr(dtype_orig, 'kind'):
+        # not a data type (e.g. a column named dtype in a pandas DataFrame)
+        dtype_orig = None
+
+    # check if the object contains several dtypes (typically a pandas
+    # DataFrame), and store them. If not, store None.
+    dtypes_orig = None
+    has_pd_integer_array = False
+    if hasattr(array, "dtypes") and hasattr(array.dtypes, '__array__'):
+        # throw warning if columns are sparse. If all columns are sparse, then
+        # array.sparse exists and sparsity will be perserved (later).
+        with suppress(ImportError):
+            from pandas.api.types import is_sparse
+            if (not hasattr(array, 'sparse') and
+                    array.dtypes.apply(is_sparse).any()):
+                warnings.warn(
+                    "pandas.DataFrame with sparse columns found."
+                    "It will be converted to a dense numpy array."
+                )
+
+        dtypes_orig = list(array.dtypes)
+        # pandas boolean dtype __array__ interface coerces bools to objects
+        for i, dtype_iter in enumerate(dtypes_orig):
+            if dtype_iter.kind == 'b':
+                dtypes_orig[i] = np.dtype(np.object)
+            elif dtype_iter.name.startswith(("Int", "UInt")):
+                # name looks like an Integer Extension Array, now check for
+                # the dtype
+                with suppress(ImportError):
+                    from pandas import (Int8Dtype, Int16Dtype,
+                                        Int32Dtype, Int64Dtype,
+                                        UInt8Dtype, UInt16Dtype,
+                                        UInt32Dtype, UInt64Dtype)
+                    if isinstance(dtype_iter, (Int8Dtype, Int16Dtype,
+                                               Int32Dtype, Int64Dtype,
+                                               UInt8Dtype, UInt16Dtype,
+                                               UInt32Dtype, UInt64Dtype)):
+                        has_pd_integer_array = True
+
+        if all(isinstance(dtype, np.dtype) for dtype in dtypes_orig):
+            dtype_orig = np.result_type(*dtypes_orig)
+
+    if dtype_numeric:
+        if dtype_orig is not None and dtype_orig.kind == "O":
+            # if input is object, convert to float.
+            dtype = np.float64
+        else:
+            dtype = None
+
+    if isinstance(dtype, (list, tuple)):
+        if dtype_orig is not None and dtype_orig in dtype:
+            # no dtype conversion required
+            dtype = None
+        else:
+            # dtype conversion required. Let's select the first element of the
+            # list of accepted types.
+            dtype = dtype[0]
+
+    if has_pd_integer_array:
+        # If there are any pandas integer extension arrays,
+        array = array.astype(dtype)
+
+    # When all dataframe columns are sparse, convert to a sparse array
+    if hasattr(array, 'sparse') and array.ndim > 1:
+        # DataFrame.sparse only supports `to_coo`
+        array = array.sparse.to_coo()
+
+    if sp.issparse(array):
+        _ensure_no_complex_data(array)
+        array = _ensure_sparse_format(array, accept_sparse=accept_sparse,
+                                      dtype=dtype, copy=copy,
+                                      force_all_finite=force_all_finite,
+                                      accept_large_sparse=accept_large_sparse)
+    else:
+        # If np.array(..) gives ComplexWarning, then we convert the warning
+        # to an error. This is needed because specifying a non complex
+        # dtype to the function converts complex to real dtype,
+        # thereby passing the test made in the lines following the scope
+        # of warnings context manager.
+        with warnings.catch_warnings():
+            try:
+                warnings.simplefilter('error', ComplexWarning)
+                if dtype is not None and np.dtype(dtype).kind in 'iu':
+                    # Conversion float -> int should not contain NaN or
+                    # inf (numpy#14412). We cannot use casting='safe' because
+                    # then conversion float -> int would be disallowed.
+                    array = np.asarray(array, order=order)
+                    if array.dtype.kind == 'f':
+                        _daal_assert_all_finite(array, allow_nan=False,
+                                                msg_dtype=dtype)
+                    array = array.astype(dtype, casting="unsafe", copy=False)
+                else:
+                    array = np.asarray(array, order=order, dtype=dtype)
+            except ComplexWarning:
+                raise ValueError("Complex data not supported\n"
+                                 "{}\n".format(array))
+
+        # It is possible that the np.array(..) gave no warning. This happens
+        # when no dtype conversion happened, for example dtype = None. The
+        # result is that np.array(..) produces an array of complex dtype
+        # and we need to catch and raise exception for such cases.
+        _ensure_no_complex_data(array) # doing nothing for DataFrame
+
+        if ensure_2d:
+            # If input is scalar raise error
+            if array.ndim == 0:
+                raise ValueError(
+                    "Expected 2D array, got scalar array instead:\narray={}.\n"
+                    "Reshape your data either using array.reshape(-1, 1) if "
+                    "your data has a single feature or array.reshape(1, -1) "
+                    "if it contains a single sample.".format(array))
+            # If input is 1D raise error
+            if array.ndim == 1:
+                raise ValueError(
+                    "Expected 2D array, got 1D array instead:\narray={}.\n"
+                    "Reshape your data either using array.reshape(-1, 1) if "
+                    "your data has a single feature or array.reshape(1, -1) "
+                    "if it contains a single sample.".format(array))
+
+        # in the future np.flexible dtypes will be handled like object dtypes
+        if dtype_numeric and np.issubdtype(array.dtype, np.flexible):
+            warnings.warn(
+                "Beginning in version 0.22, arrays of bytes/strings will be "
+                "converted to decimal numbers if dtype='numeric'. "
+                "It is recommended that you convert the array to "
+                "a float dtype before using it in scikit-learn, "
+                "for example by using "
+                "your_array = your_array.astype(np.float64).",
+                FutureWarning, stacklevel=2)
+
+        # make sure we actually converted to numeric:
+        if dtype_numeric and array.dtype.kind == "O":
+            array = array.astype(np.float64)
+        if not allow_nd and array.ndim >= 3:
+            raise ValueError("Found array with dim %d. %s expected <= 2."
+                             % (array.ndim, estimator_name))
+
+        if force_all_finite:
+            _daal_assert_all_finite(array,
+                                    allow_nan=force_all_finite == 'allow-nan')
+
+    if ensure_min_samples > 0:
+        n_samples = _num_samples(array)
+        if n_samples < ensure_min_samples:
+            raise ValueError("Found array with %d sample(s) (shape=%s) while a"
+                             " minimum of %d is required%s."
+                             % (n_samples, array.shape, ensure_min_samples,
+                                context))
+
+    if ensure_min_features > 0 and array.ndim == 2:
+        n_features = array.shape[1]
+        if n_features < ensure_min_features:
+            raise ValueError("Found array with %d feature(s) (shape=%s) while"
+                             " a minimum of %d is required%s."
+                             % (n_features, array.shape, ensure_min_features,
+                                context))
+
+    if copy and np.may_share_memory(array, array_orig):
+        array = np.array(array, dtype=dtype, order=order)
+
+    return array
+
+
+def _daal_check_X_y(X, y, accept_sparse=False, *, accept_large_sparse=True,
+                    dtype="numeric", order=None, copy=False, force_all_finite=True,
+                    ensure_2d=True, allow_nd=False, multi_output=False,
+                    ensure_min_samples=1, ensure_min_features=1, y_numeric=False,
+                    estimator=None):
+    """Input validation for standard estimators.
+
+    Checks X and y for consistent length, enforces X to be 2D and y 1D. By
+    default, X is checked to be non-empty and containing only finite values.
+    Standard input checks are also applied to y, such as checking that y
+    does not have np.nan or np.inf targets. For multi-label y, set
+    multi_output=True to allow 2D and sparse y. If the dtype of X is
+    object, attempt converting to float, raising on failure.
+
+    Parameters
+    ----------
+    X : nd-array, list or sparse matrix
+        Input data.
+
+    y : nd-array, list or sparse matrix
+        Labels.
+
+    accept_sparse : string, boolean or list of string (default=False)
+        String[s] representing allowed sparse matrix formats, such as 'csc',
+        'csr', etc. If the input is sparse but not in the allowed format,
+        it will be converted to the first listed format. True allows the input
+        to be any format. False means that a sparse matrix input will
+        raise an error.
+
+    accept_large_sparse : bool (default=True)
+        If a CSR, CSC, COO or BSR sparse matrix is supplied and accepted by
+        accept_sparse, accept_large_sparse will cause it to be accepted only
+        if its indices are stored with a 32-bit dtype.
+
+        .. versionadded:: 0.20
+
+    dtype : string, type, list of types or None (default="numeric")
+        Data type of result. If None, the dtype of the input is preserved.
+        If "numeric", dtype is preserved unless array.dtype is object.
+        If dtype is a list of types, conversion on the first type is only
+        performed if the dtype of the input is not in the list.
+
+    order : 'F', 'C' or None (default=None)
+        Whether an array will be forced to be fortran or c-style.
+
+    copy : boolean (default=False)
+        Whether a forced copy will be triggered. If copy=False, a copy might
+        be triggered by a conversion.
+
+    force_all_finite : boolean or 'allow-nan', (default=True)
+        Whether to raise an error on np.inf, np.nan, pd.NA in X. This parameter
+        does not influence whether y can have np.inf, np.nan, pd.NA values.
+        The possibilities are:
+
+        - True: Force all values of X to be finite.
+        - False: accepts np.inf, np.nan, pd.NA in X.
+        - 'allow-nan': accepts only np.nan or pd.NA values in X. Values cannot
+          be infinite.
+
+        .. versionadded:: 0.20
+           ``force_all_finite`` accepts the string ``'allow-nan'``.
+
+        .. versionchanged:: 0.23
+           Accepts `pd.NA` and converts it into `np.nan`
+
+    ensure_2d : boolean (default=True)
+        Whether to raise a value error if X is not 2D.
+
+    allow_nd : boolean (default=False)
+        Whether to allow X.ndim > 2.
+
+    multi_output : boolean (default=False)
+        Whether to allow 2D y (array or sparse matrix). If false, y will be
+        validated as a vector. y cannot have np.nan or np.inf values if
+        multi_output=True.
+
+    ensure_min_samples : int (default=1)
+        Make sure that X has a minimum number of samples in its first
+        axis (rows for a 2D array).
+
+    ensure_min_features : int (default=1)
+        Make sure that the 2D array has some minimum number of features
+        (columns). The default value of 1 rejects empty datasets.
+        This check is only enforced when X has effectively 2 dimensions or
+        is originally 1D and ``ensure_2d`` is True. Setting to 0 disables
+        this check.
+
+    y_numeric : boolean (default=False)
+        Whether to ensure that y has a numeric type. If dtype of y is object,
+        it is converted to float64. Should only be used for regression
+        algorithms.
+
+    estimator : str or estimator instance (default=None)
+        If passed, include the name of the estimator in warning messages.
+
+    Returns
+    -------
+    X_converted : object
+        The converted and validated X.
+
+    y_converted : object
+        The converted and validated y.
+    """
+    if y is None:
+        raise ValueError("y cannot be None")
+
+    X = _daal_check_array(X, accept_sparse=accept_sparse,
+                    accept_large_sparse=accept_large_sparse,
+                    dtype=dtype, order=order, copy=copy,
+                    force_all_finite=force_all_finite,
+                    ensure_2d=ensure_2d, allow_nd=allow_nd,
+                    ensure_min_samples=ensure_min_samples,
+                    ensure_min_features=ensure_min_features,
+                    estimator=estimator)
+    if multi_output:
+        y = _daal_check_array(y, accept_sparse='csr', force_all_finite=True,
+                        ensure_2d=False, dtype=None)
+    else:
+        y = column_or_1d(y, warn=True)
+        _daal_assert_all_finite(y)
+    if y_numeric and hasattr(y, 'dtype') and y.dtype.kind == 'O':
+        y = y.astype(np.float64)
+
+    check_consistent_length(X, y)
+
+    return X, y


### PR DESCRIPTION
List of changes:
* sklearn's ```check_array(), check_X_y(), and validate_data()``` have been modified to exclude ```pandas.DataFrame``` to ```numpy.array``` conversion
* new ```_daal_check_array(), _daal_check_X_y(), and _daal_validate_data()``` have been used in Linear Regresion
* ```getFPType()``` has been modified to work with ```pandas.DataFrame```
* a couple of tests have been added