### PR TITLE
increasing of timout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,7 @@ jobs:
             conda build --python=37 --override-channels -c conda-forge -c intel -c defaults --output-folder /tmp/out --no-test conda-recipe
       - run:
           name: Testing sklearn patches
+          no_output_timeout: 20m
           command: |
             export PATH=~/miniconda/bin:$PATH
             . ~/miniconda/etc/profile.d/conda.sh
@@ -65,6 +66,7 @@ jobs:
             conda build --python=37 --override-channels -c conda-forge -c intel --output-folder /tmp/out --no-test conda-recipe
       - run:
           name: Testing sklearn patches
+          no_output_timeout: 20m
           command: |
             export PATH=~/miniconda/bin:$PATH
             . ~/miniconda/etc/profile.d/conda.sh


### PR DESCRIPTION
Some of Scikit-Learn tests are too huge and take a lot of time. That is why we are getting errors like:
Too long with no output (exceeded 10m0s): context deadline exceeded
https://app.circleci.com/pipelines/github/IntelPython/daal4py/907/workflows/904faaa5-d108-4213-986a-f66084529c87/jobs/1321/steps

This is the default timeout.
This PR increases it to 20m.