### PR TITLE
test_sparse_realdata and test_predict_proba_multilabel

### DIFF
--- a/deselected_tests.yaml
+++ b/deselected_tests.yaml
@@ -14,7 +14,7 @@ deselected_tests:
   # See: https://github.com/scikit-learn/scikit-learn/issues/12738
   - svm/tests/test_svm.py::test_sample_weights
   - svm/tests/test_svm.py::test_precomputed
-  - svm/tests/test_sparse.py::test_sparse
+  - svm/tests/test_sparse.py::test_sparse_realdata
   - svm/tests/test_sparse.py::test_svc_iris
   - ensemble/tests/test_bagging.py::test_sparse_classification
 
@@ -67,3 +67,7 @@ deselected_tests:
 
   # DAAL doesn't support sample_weight (back to Sklearn), insufficient accuracy (similar to previous cases)
   - linear_model/tests/test_coordinate_descent.py::test_enet_sample_weight_consistency >=0.23
+
+  # We have difference (Max absolute difference: 1.97215226e-31) in computing of log_proba with np.log(y_proba)
+  # Looks like that our modifications in numpy give this
+  - neural_network/tests/test_mlp.py::test_predict_proba_multilabel

--- a/deselected_tests.yaml
+++ b/deselected_tests.yaml
@@ -69,5 +69,5 @@ deselected_tests:
   - linear_model/tests/test_coordinate_descent.py::test_enet_sample_weight_consistency >=0.23
 
   # We have difference (Max absolute difference: 1.97215226e-31) in computing of log_proba with np.log(y_proba)
-  # Looks like that our modifications in numpy give this
+  # Looks like using IDP NumPy is the cause for the failure due to use of more aggressive compiler optimization when compile NumPy UFunc loops
   - neural_network/tests/test_mlp.py::test_predict_proba_multilabel


### PR DESCRIPTION
```
    def test_predict_proba_multilabel():
        # Test that predict_proba works as expected for multilabel.
        # Multilabel should not use softmax which makes probabilities sum to 1
        X, Y = make_multilabel_classification(n_samples=50, random_state=0,
                                              return_indicator=True)
        n_samples, n_classes = Y.shape
    
        clf = MLPClassifier(solver='lbfgs', hidden_layer_sizes=30,
                            random_state=0)
        clf.fit(X, Y)
        y_proba = clf.predict_proba(X)
    
        assert y_proba.shape == (n_samples, n_classes)
        assert_array_equal(y_proba > 0.5, Y)
    
        y_log_proba = clf.predict_log_proba(X)
        proba_max = y_proba.argmax(axis=1)
        proba_log_max = y_log_proba.argmax(axis=1)
    
        assert (y_proba.sum(1) - 1).dot(y_proba.sum(1) - 1) > 1e-10
        assert_array_equal(proba_max, proba_log_max)
>       assert_array_equal(y_log_proba, np.log(y_proba))
E       AssertionError: 
E       Arrays are not equal
E       
E       Mismatched elements: 1 / 250 (0.4%)
E       Max absolute difference: 1.97215226e-31
E       Max relative difference: 1.48029737e-16
E        x: array([[-2.455893e+01, -1.487065e+01, -1.958819e-05, -4.616044e-07,
E                0.000000e+00],
E              [-2.863282e+01, -4.438337e+01,  0.000000e+00, -1.289439e+02,...
E        y: array([[-2.455893e+01, -1.487065e+01, -1.958819e-05, -4.616044e-07,
E                0.000000e+00],
E              [-2.863282e+01, -4.438337e+01,  0.000000e+00, -1.289439e+02,...
```