### PR TITLE
Add new deselected test for ridge regression

### DIFF
--- a/deselected_tests.yaml
+++ b/deselected_tests.yaml
@@ -75,4 +75,5 @@ deselected_tests:
 
   # On small datasets, the regression coefficients for multi-target problem differ from scikit-learn. Coefficients matches for first label only.
   # For big data the coefficients are close.
+  # See: https://github.com/IntelPython/daal4py/issues/275
   - linear_model/tests/test_ridge.py::test_ridge_cv_individual_penalties

--- a/deselected_tests.yaml
+++ b/deselected_tests.yaml
@@ -72,3 +72,7 @@ deselected_tests:
   # We have difference (Max absolute difference: 1.97215226e-31) in computing of log_proba with np.log(y_proba)
   # Looks like using IDP NumPy is the cause for the failure due to use of more aggressive compiler optimization when compile NumPy UFunc loops
   - neural_network/tests/test_mlp.py::test_predict_proba_multilabel
+
+  # On small datasets, the regression coefficients for multi-target problem differ from scikit-learn. Coefficients matches for first label only.
+  # For big data the coefficients are close.
+  - linear_model/tests/test_ridge.py::test_ridge_cv_individual_penalties


### PR DESCRIPTION
On small datasets, the regression coefficients for multi-target problem differ from scikit-learn. Coefficients matches for first label only. For big data the coefficients are close.
![image](https://user-images.githubusercontent.com/35104773/91444750-de847480-e87d-11ea-8cf5-7b06827185d7.png)
