### PR TITLE
Interoperability with dpctl

### DIFF
--- a/conda-recipe/bld.bat
+++ b/conda-recipe/bld.bat
@@ -1,8 +1,26 @@
 rem set NO_DIST=1
 
+set PATH=%PATH%;%PREFIX%\Library\bin\libfabric
+
+rem if dpc++ vars path is specified
+IF DEFINED DPCPPROOT (
+    echo "=============DPCPP==============="
+    call "%DPCPPROOT%\env\vars.bat"
+    set "CC=dpcpp.exe"
+    set "CXX=dpcpp.exe"
+)
+
+rem if DAALROOT not exists then provide PREFIX
+rem otherwise use library directly from the path provided
+
+IF NOT DEFINED DAALROOT ( 
+    set DAALROOT=%PREFIX% 
+) ELSE (
+    call conda remove daal daal-include --force -y
+)
+
+set DAALROOT=%PREFIX% 
 set DAAL4PY_VERSION=%PKG_VERSION%
 set MPIROOT=%PREFIX%\Library
-set DAALROOT=%PREFIX%
-set PATH=%PATH%;%PREFIX%\Library\bin\libfabric
 
 %PYTHON% setup.py install

--- a/conda-recipe/bld.bat
+++ b/conda-recipe/bld.bat
@@ -1,26 +1,16 @@
 rem set NO_DIST=1
+ 
+set DAAL4PY_VERSION=%PKG_VERSION%
+set MPIROOT=%PREFIX%\Library
 
-set PATH=%PATH%;%PREFIX%\Library\bin\libfabric
+IF NOT DEFINED DAALROOT (set DAALROOT=%PREFIX%) 
 
-rem if dpc++ vars path is specified
 IF DEFINED DPCPPROOT (
-    echo "=============DPCPP==============="
     call "%DPCPPROOT%\env\vars.bat"
     set "CC=dpcpp.exe"
     set "CXX=dpcpp.exe"
 )
 
-rem if DAALROOT not exists then provide PREFIX
-rem otherwise use library directly from the path provided
-
-IF NOT DEFINED DAALROOT ( 
-    set DAALROOT=%PREFIX% 
-) ELSE (
-    call conda remove daal daal-include --force -y
-)
-
-set DAALROOT=%PREFIX% 
-set DAAL4PY_VERSION=%PKG_VERSION%
-set MPIROOT=%PREFIX%\Library
+set PATH=%PATH%;%PREFIX%\Library\bin\libfabric
 
 %PYTHON% setup.py install

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -13,6 +13,7 @@ build:
     include_recipe: False
     script_env:
      - DPCPPROOT
+     - DPCTLROOT
      - DAALROOT
      - TBBROOT
     ignore_run_exports:

--- a/examples/run_examples.py
+++ b/examples/run_examples.py
@@ -106,6 +106,7 @@ req_version['sycl/bf_knn_classification_batch.py'] = (2021,105)
 req_version['sycl/dbscan_batch.py'] = (2021,110) # hangs in beta08, need to be fixed
 req_version['sycl/gradient_boosted_regression_batch.py'] = (2021,105)
 req_version['sycl/linear_regression_batch.py'] = (2021,110) # hangs in beta08, need to be fixed
+req_version['sycl/kmeans_batch.py'] = (2021, 110) # not equal results for host and gpu runs
 req_version['sycl/svm_batch.py'] = (2021,107)
 
 req_device = defaultdict(lambda:[])

--- a/examples/sycl/bf_knn_classification_batch.py
+++ b/examples/sycl/bf_knn_classification_batch.py
@@ -67,7 +67,7 @@ def main(readcsv=read_csv, method='defaultDense'):
     predict_data = to_numpy(predict_data)
 
     try:
-        from dppl import device_context, device_type
+        from dpctx import device_context, device_type
         gpu_context = lambda: device_context(device_type.gpu, 0)
     except:
         from daal4py.oneapi import sycl_context

--- a/examples/sycl/covariance_batch.py
+++ b/examples/sycl/covariance_batch.py
@@ -32,7 +32,7 @@ except:
     read_csv = lambda f, c=None, t=np.float64: np.loadtxt(f, usecols=c, delimiter=',', ndmin=2)
 
 try:
-    from dppl import device_context, device_type
+    from dpctl import device_context, device_type
     with device_context(device_type.gpu, 0):
         gpu_available=True
 except:
@@ -79,7 +79,7 @@ def main(readcsv=read_csv, method='defaultDense'):
     data = to_numpy(data)
 
     try:
-        from dppl import device_context, device_type
+        from dpctl import device_context, device_type
         gpu_context = lambda: device_context(device_type.gpu, 0)
         cpu_context = lambda: device_context(device_type.cpu, 0)
     except:

--- a/examples/sycl/covariance_streaming.py
+++ b/examples/sycl/covariance_streaming.py
@@ -29,7 +29,7 @@ sys.path.insert(0, '..')
 from stream import read_next
 
 try:
-    from dppl import device_context, device_type
+    from dpctx import device_context, device_type
     with device_context(device_type.gpu, 0):
         gpu_available=True
 except:
@@ -72,7 +72,7 @@ def main(readcsv=None, method='defaultDense'):
     result_classic = algo.finalize()
 
     try:
-        from dppl import device_context, device_type
+        from dpctx import device_context, device_type
         gpu_context = lambda: device_context(device_type.gpu, 0)
         cpu_context = lambda: device_context(device_type.cpu, 0)
     except:

--- a/examples/sycl/dbscan_batch.py
+++ b/examples/sycl/dbscan_batch.py
@@ -32,7 +32,7 @@ except:
     read_csv = lambda f, c, t=np.float64: np.loadtxt(f, usecols=c, delimiter=',', ndmin=2)
 
 try:
-    from dppl import device_context, device_type
+    from dpctx import device_context, device_type
     with device_context(device_type.gpu, 0):
         gpu_available=True
 except:
@@ -84,7 +84,7 @@ def main(readcsv=read_csv, method='defaultDense'):
     data = to_numpy(data)
 
     try:
-        from dppl import device_context, device_type
+        from dpctx import device_context, device_type
         gpu_context = lambda: device_context(device_type.gpu, 0)
         cpu_context = lambda: device_context(device_type.cpu, 0)
     except:

--- a/examples/sycl/gradient_boosted_regression_batch.py
+++ b/examples/sycl/gradient_boosted_regression_batch.py
@@ -81,7 +81,7 @@ def main(readcsv=read_csv, method='defaultDense'):
     test_indep_data = to_numpy(test_indep_data)
 
     try:
-        from dppl import device_context, device_type
+        from dpctx import device_context, device_type
         gpu_context = lambda: device_context(device_type.gpu, 0)
     except:
         from daal4py.oneapi import sycl_context

--- a/examples/sycl/kmeans_batch.py
+++ b/examples/sycl/kmeans_batch.py
@@ -32,7 +32,7 @@ except:
     read_csv = lambda f, c, t=np.float64: np.loadtxt(f, usecols=c, delimiter=',', ndmin=2)
 
 try:
-    from dppl import device_context, device_type
+    from dpctx import device_context, device_type
     with device_context(device_type.gpu, 0):
         gpu_available=True
 except:
@@ -90,7 +90,7 @@ def main(readcsv=read_csv, method='randomDense'):
     data = to_numpy(data)
 
     try:
-        from dppl import device_context, device_type
+        from dpctx import device_context, device_type
         gpu_context = lambda: device_context(device_type.gpu, 0)
         cpu_context = lambda: device_context(device_type.cpu, 0)
     except:

--- a/examples/sycl/linear_regression_batch.py
+++ b/examples/sycl/linear_regression_batch.py
@@ -32,7 +32,7 @@ except:
     read_csv = lambda f, c, t=np.float64: np.loadtxt(f, usecols=c, delimiter=',', ndmin=2)
 
 try:
-    from dppl import device_context, device_type
+    from dpctx import device_context, device_type
     with device_context(device_type.gpu, 0):
         gpu_available=True
 except:
@@ -91,7 +91,7 @@ def main(readcsv=read_csv, method='defaultDense'):
     test_indep_data = to_numpy(test_indep_data)
 
     try:
-        from dppl import device_context, device_type
+        from dpctx import device_context, device_type
         gpu_context = lambda: device_context(device_type.gpu, 0)
         cpu_context = lambda: device_context(device_type.cpu, 0)
     except:

--- a/examples/sycl/log_reg_binary_dense_batch.py
+++ b/examples/sycl/log_reg_binary_dense_batch.py
@@ -32,7 +32,7 @@ except:
     read_csv = lambda f, c, t=np.float64: np.loadtxt(f, usecols=c, delimiter=',', ndmin=2)
 
 try:
-    from dppl import device_context, device_type
+    from dpctx import device_context, device_type
     with device_context(device_type.gpu, 0):
         gpu_available=True
 except:
@@ -92,7 +92,7 @@ def main(readcsv=read_csv, method='defaultDense'):
     predict_data = to_numpy(predict_data)
 
     try:
-        from dppl import device_context, device_type
+        from dpctx import device_context, device_type
         gpu_context = lambda: device_context(device_type.gpu, 0)
         cpu_context = lambda: device_context(device_type.cpu, 0)
     except:

--- a/examples/sycl/log_reg_dense_batch.py
+++ b/examples/sycl/log_reg_dense_batch.py
@@ -32,7 +32,7 @@ except:
     read_csv = lambda f, c, t=np.float64: np.loadtxt(f, usecols=c, delimiter=',', ndmin=2)
 
 try:
-    from dppl import device_context, device_type
+    from dpctx import device_context, device_type
     with device_context(device_type.gpu, 0):
         gpu_available=True
 except:
@@ -95,7 +95,7 @@ def main(readcsv=read_csv, method='defaultDense'):
     predict_data = to_numpy(predict_data)
 
     try:
-        from dppl import device_context, device_type
+        from dpctx import device_context, device_type
         gpu_context = lambda: device_context(device_type.gpu, 0)
         cpu_context = lambda: device_context(device_type.cpu, 0)
     except:

--- a/examples/sycl/low_order_moms_dense_batch.py
+++ b/examples/sycl/low_order_moms_dense_batch.py
@@ -32,7 +32,7 @@ except:
     read_csv = lambda f, c, t=np.float64: np.loadtxt(f, usecols=c, delimiter=',', ndmin=2)
 
 try:
-    from dppl import device_context, device_type
+    from dpctx import device_context, device_type
     with device_context(device_type.gpu, 0):
         gpu_available=True
 except:
@@ -77,7 +77,7 @@ def main(readcsv=read_csv, method="defaultDense"):
     data = to_numpy(data)
 
     try:
-        from dppl import device_context, device_type
+        from dpctx import device_context, device_type
         gpu_context = lambda: device_context(device_type.gpu, 0)
         cpu_context = lambda: device_context(device_type.cpu, 0)
     except:

--- a/examples/sycl/low_order_moms_streaming.py
+++ b/examples/sycl/low_order_moms_streaming.py
@@ -29,7 +29,7 @@ sys.path.insert(0, '..')
 from stream import read_next
 
 try:
-    from dppl import device_context, device_type
+    from dpctx import device_context, device_type
     with device_context(device_type.gpu, 0):
         gpu_available=True
 except:
@@ -74,7 +74,7 @@ def main(readcsv=None, method='defaultDense'):
     result_classic = algo.finalize()
 
     try:
-        from dppl import device_context, device_type
+        from dpctx import device_context, device_type
         gpu_context = lambda: device_context(device_type.gpu, 0)
         cpu_context = lambda: device_context(device_type.cpu, 0)
     except:

--- a/examples/sycl/pca_batch.py
+++ b/examples/sycl/pca_batch.py
@@ -32,7 +32,7 @@ except:
     read_csv = lambda f, c=None, t=np.float64: np.loadtxt(f, usecols=c, delimiter=',', ndmin=2)
 
 try:
-    from dppl import device_context, device_type
+    from dpctx import device_context, device_type
     with device_context(device_type.gpu, 0):
         gpu_available=True
 except:
@@ -81,7 +81,7 @@ def main(readcsv=read_csv, method='svdDense'):
     data = to_numpy(data)
 
     try:
-        from dppl import device_context, device_type
+        from dpctx import device_context, device_type
         gpu_context = lambda: device_context(device_type.gpu, 0)
         cpu_context = lambda: device_context(device_type.cpu, 0)
     except:

--- a/examples/sycl/pca_transform_batch.py
+++ b/examples/sycl/pca_transform_batch.py
@@ -32,7 +32,7 @@ except:
     read_csv = lambda f, c, t=np.float64: np.loadtxt(f, usecols=c, delimiter=',', ndmin=2)
 
 try:
-    from dppl import device_context, device_type
+    from dpctx import device_context, device_type
     with device_context(device_type.gpu, 0):
         gpu_available=True
 except:
@@ -83,7 +83,7 @@ def main(readcsv=read_csv, method='svdDense'):
     data = to_numpy(data)
 
     try:
-        from dppl import device_context, device_type
+        from dpctx import device_context, device_type
         gpu_context = lambda: device_context(device_type.gpu, 0)
         cpu_context = lambda: device_context(device_type.cpu, 0)
     except:

--- a/examples/sycl/sklearn_sycl.py
+++ b/examples/sycl/sklearn_sycl.py
@@ -29,10 +29,10 @@ from sklearn.cluster import DBSCAN
 
 from sklearn.datasets import load_iris
 
-dppl_available = False
+dpctx_available = False
 try:
-    from dppl import device_context, device_type
-    dppl_available = True
+    from dpctx import device_context, device_type
+    dpctx_available = True
 except:
     try:
         from daal4py.oneapi import sycl_context
@@ -41,7 +41,7 @@ except:
         sycl_extention_available = False
 
 gpu_available = False
-if dppl_available:
+if dpctx_available:
     try:
         with device_context(device_type.gpu, 0):
             gpu_available = True
@@ -132,7 +132,7 @@ def dbscan():
     print(clustering)
 
 def get_context(device):
-    if dppl_available:
+    if dpctx_available:
         return device_context(device, 0)
     elif sycl_extention_available:
         return sycl_context(device)
@@ -150,7 +150,7 @@ if __name__ == "__main__":
                ]
     devices = []
 
-    if dppl_available:
+    if dpctx_available:
         devices.append(device_type.host)
         devices.append(device_type.cpu)
         if gpu_available:

--- a/examples/sycl/sklearn_sycl.py
+++ b/examples/sycl/sklearn_sycl.py
@@ -134,7 +134,7 @@ def dbscan():
 def get_context(device):
     if dpctx_available:
         return device_context(device, 0)
-    elif sycl_extention_available:
+    if sycl_extention_available:
         return sycl_context(device)
     else:
         return None

--- a/examples/sycl/svm_batch.py
+++ b/examples/sycl/svm_batch.py
@@ -32,7 +32,7 @@ except:
     read_csv = lambda f, c, t=np.float64: np.loadtxt(f, usecols=c, delimiter=',', ndmin=2)
 
 try:
-    from dppl import device_context, device_type
+    from dpctx import device_context, device_type
     with device_context(device_type.gpu, 0):
         gpu_available=True
 except:
@@ -93,7 +93,7 @@ def main(readcsv=read_csv):
     predict_data = to_numpy(predict_data)
 
     try:
-        from dppl import device_context, device_type
+        from dpctx import device_context, device_type
         gpu_context = lambda: device_context(device_type.gpu, 0)
     except:
         from daal4py.oneapi import sycl_context

--- a/generator/wrapper_gen.py
+++ b/generator/wrapper_gen.py
@@ -248,19 +248,19 @@ def _execute_with_context(func):
     def exec_func(*args, **keyArgs):
         # we check is DPPY imported or not
         # possible we should check are we in defined context or not
-        if 'dppl' in sys.modules:
-            from dppl import runtime as rt
-            from _oneapi import set_queue_to_daal_context, reset_daal_context
+        if 'dpctl' in sys.modules:
+            from dpctl import is_in_device_context, get_current_queue
 
-            queue = rt.get_current_queue()
-            set_queue_to_daal_context(queue)
+            if is_in_device_context():
+                from _dpctl_interop import set_current_queue_to_daal_context, reset_daal_context
 
-            res = func(*args, **keyArgs)
+                set_current_queue_to_daal_context()
+                res = func(*args, **keyArgs)
+                reset_daal_context()
 
-            reset_daal_context()
-            return res
-        else:
-            return func(*args, **keyArgs)
+                return res
+
+        return func(*args, **keyArgs)
     return exec_func
 '''
 

--- a/setup.py
+++ b/setup.py
@@ -115,7 +115,7 @@ if dpcpp:
         DPCPP_LIBS.append('daal_sycl')
 
     if dpctl:
-        # TODO: dpctl directory paths rely on conda environment
+        # At now, dpctl directory paths rely on conda environment
         DPCTL_LIBDIRS = [jp(dpctl_root, 'lib')]
         DPCTL_INCDIRS = [jp(dpctl_root, 'include')]
         DPCTL_LIBS = ['DPPLSyclInterface']

--- a/setup.py
+++ b/setup.py
@@ -115,8 +115,11 @@ if dpcpp:
         DPCPP_LIBS.append('daal_sycl')
 
     if dpctl:
-        # At now, dpctl directory paths rely on conda environment
-        DPCTL_LIBDIRS = [jp(dpctl_root, 'lib')]
+        # if custom dpctl library directory is specified
+        if 'DPCTL_LIBPATH' in os.environ:
+            DPCTL_LIBDIRS = [os.environ['DPCTL_LIBPATH']]
+        else:
+            DPCTL_LIBDIRS = [jp(dpctl_root, 'lib')]
         DPCTL_INCDIRS = [jp(dpctl_root, 'include')]
         DPCTL_LIBS = ['DPPLSyclInterface']
     else:

--- a/setup.py
+++ b/setup.py
@@ -193,15 +193,22 @@ def getpyexts():
                                 extra_compile_args=eca,
                                 extra_link_args=ela,
                                 libraries=libraries_plat + MPI_LIBS,
-                                library_dirs=DAAL_LIBDIRS,
+                                library_dirs=DAAL_LIBDIRS + MPI_LIBDIRS,
                                 language='c++'),
     ])
+
+    eca_dpcpp = eca.copy()
+    if IS_WIN:
+        eca_dpcpp.remove('/MD')
+        eca_dpcpp += ['/MT'] # daal_sycl is static lib - requires to link standard library statically
+    eca_dpcpp += ['-fsycl']
+
     if dpcpp:
         exts.extend(cythonize(Extension('_oneapi',
                                         [os.path.abspath('src/oneapi/oneapi.pyx'),],
                                         depends=['src/oneapi/oneapi.h',],
                                         include_dirs=include_dir_plat + [np.get_include()],
-                                        extra_compile_args=eca + ['-fsycl'],
+                                        extra_compile_args=eca_dpcpp,
                                         extra_link_args=ela,
                                         libraries=libraries_plat + DPCPP_LIBS,
                                         library_dirs=DAAL_LIBDIRS + DPCPP_LIBDIRS,
@@ -212,7 +219,7 @@ def getpyexts():
                                          os.path.abspath('src/dpctl_interop/daal_context_service.cpp'),],
                                         depends=['src/dpctl_interop/daal_context_service.h',],
                                         include_dirs=include_dir_plat + DPCTL_INCDIRS,
-                                        extra_compile_args=eca + ['-fsycl'],
+                                        extra_compile_args=eca_dpcpp,
                                         extra_link_args=ela,
                                         libraries=libraries_plat + DPCPP_LIBS + DPCTL_LIBS,
                                         library_dirs=DAAL_LIBDIRS + DPCPP_LIBDIRS + DPCTL_LIBDIRS,

--- a/src/dpctl_interop/daal_context_service.cpp
+++ b/src/dpctl_interop/daal_context_service.cpp
@@ -1,0 +1,48 @@
+/*******************************************************************************
+* Copyright 2020 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+******************************************************************************/
+
+#include "dpctl_interop/daal_context_service.h"
+
+#include "daal_sycl.h"
+#include "dppl_sycl_types.h"
+#include "dppl_sycl_queue_manager.h"
+
+#ifndef DAAL_SYCL_INTERFACE
+#include <type_traits>
+static_assert(false, "DAAL_SYCL_INTERFACE not defined")
+#endif
+
+void _dppl_set_current_queue_to_daal_context()
+{
+    auto dppl_queue = DPPLQueueMgr_GetCurrentQueue();
+    if(dppl_queue != NULL)
+    {
+        cl::sycl::queue * sycl_queue = reinterpret_cast<cl::sycl::queue*>(dppl_queue);
+
+        daal::services::SyclExecutionContext ctx (*sycl_queue);
+        daal::services::Environment::getInstance()->setDefaultExecutionContext(ctx);
+    }
+    else
+    {
+        throw std::runtime_error("Cannot set daal context: Pointer to queue object is NULL");
+    }
+}
+
+void _dppl_reset_daal_context()
+{
+    daal::services::CpuExecutionContext ctx;
+    daal::services::Environment::getInstance()->setDefaultExecutionContext(ctx);
+}

--- a/src/dpctl_interop/daal_context_service.h
+++ b/src/dpctl_interop/daal_context_service.h
@@ -1,0 +1,24 @@
+/*******************************************************************************
+* Copyright 2020 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+******************************************************************************/
+
+#ifndef __DAAL_CONTEXT_SERVICE_H_INCLUDED__
+#define __DAAL_CONTEXT_SERVICE_H_INCLUDED__
+
+void _dppl_set_current_queue_to_daal_context();
+
+void _dppl_reset_daal_context();
+
+#endif // __DAAL_CONTEXT_SERVICE_H_INCLUDED__

--- a/src/dpctl_interop/dpctl_interop.pyx
+++ b/src/dpctl_interop/dpctl_interop.pyx
@@ -1,0 +1,28 @@
+#*******************************************************************************
+# Copyright 2014-2019 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#******************************************************************************/
+
+# distutils: language = c++
+# cython: language_level=2
+
+cdef extern from "dpctl_interop/daal_context_service.h":
+    void _dppl_set_current_queue_to_daal_context() except +
+    void _dppl_reset_daal_context() except +
+
+def set_current_queue_to_daal_context():
+    _dppl_set_current_queue_to_daal_context()
+
+def reset_daal_context():
+    _dppl_reset_daal_context()

--- a/src/oneapi/oneapi.h
+++ b/src/oneapi/oneapi.h
@@ -68,29 +68,6 @@ static std::string to_std_string(PyObject * o)
     return PyUnicode_AsUTF8(o);
 }
 
-void c_set_queue_to_daal_context(PyObject* queue_object)
-{
-    if(queue_object != NULL)
-    {
-        if(PyCapsule_IsValid(queue_object, NULL) == 0) { throw std::runtime_error("Cannot set daal context: invalid queue object"); }
-        cl::sycl::queue * queue_ptr = (cl::sycl::queue*)PyCapsule_GetPointer(queue_object, NULL);
-        if(PyErr_Occurred()) { PyErr_Print(); throw std::runtime_error("Python Error"); }
-
-        daal::services::SyclExecutionContext ctx (*queue_ptr);
-        daal::services::Environment::getInstance()->setDefaultExecutionContext(ctx);
-    }
-    else
-    {
-        throw std::runtime_error("Cannot set daal context: Pointer to queue object is NULL");
-    }
-}
-
-void c_reset_daal_context()
-{
-    daal::services::CpuExecutionContext ctx;
-    daal::services::Environment::getInstance()->setDefaultExecutionContext(ctx);
-}
-
 // take a raw array and convert to sycl buffer
 template<typename T>
 inline cl::sycl::buffer<T, 1> * tosycl(T * ptr, int * shape)

--- a/src/oneapi/oneapi.pyx
+++ b/src/oneapi/oneapi.pyx
@@ -32,8 +32,6 @@ cdef extern from "oneapi/oneapi.h":
     std_string to_std_string(PyObject * o) except +
 
     void * c_make_py_from_sycltable(void * ptr, int typ) except +
-    void c_set_queue_to_daal_context(PyObject* queue_object) except +
-    void c_reset_daal_context() except +
 
 
 
@@ -131,10 +129,3 @@ cdef api object make_py_from_sycltable(void * ptr, int typ, int d1, int d2):
         res.__inilz__(<long>buff, typ, d1, d2)
         return res
     return None
-
-
-def set_queue_to_daal_context(queue):
-    c_set_queue_to_daal_context(<PyObject*>queue)
-
-def reset_daal_context():
-    c_reset_daal_context()


### PR DESCRIPTION
Fix of the **Data parallel control** module integration (formerly known as DPPY, DPPL). All the code that depends on dpctl is moved to a separate module to avoid unwanted dependency in the big daal4py.