### PR TITLE
Update legacy command substitution notation

### DIFF
--- a/.circleci/run_and_compare.sh
+++ b/.circleci/run_and_compare.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
 cd ~/daal4py-ci/.circleci
 touch ~/d4p.out ~/skl.out
-export DESELECTED_TESTS=`python deselect_tests.py ../deselected_tests.yaml --absolute`
+export DESELECTED_TESTS=$(python deselect_tests.py ../deselected_tests.yaml --absolute)
 echo "-m daal4py -m pytest ${DESELECTED_TESTS} -q -ra --disable-warnings --pyargs sklearn"
 # It is important for pytest to work in a separate test folder to not discover tests in ~/miniconda folder
 cd && ((python -m daal4py -m pytest ${DESELECTED_TESTS} -ra --disable-warnings --pyargs sklearn | tee ~/d4p.out) || true)
 cd && ((python -m pytest ${DESELECTED_TESTS} -ra --disable-warnings --pyargs sklearn | tee ~/skl.out) || true)
 # extract status strings
-export D4P=`grep -E "=(\s\d*\w*,?)+ in .*\s=" ~/d4p.out`
-export SKL=`grep -E "=(\s\d*\w*,?)+ in .*\s=" ~/skl.out`
+export D4P=$(grep -E "=(\s\d*\w*,?)+ in .*\s=" ~/d4p.out)
+export SKL=$(grep -E "=(\s\d*\w*,?)+ in .*\s=" ~/skl.out)
 tar cjf $1 ~/d4p.out ~/skl.out
 echo "Summary of patched run: " $D4P
 echo "Summary of unpatched run: " $SKL

--- a/conda-recipe/build.sh
+++ b/conda-recipe/build.sh
@@ -17,7 +17,7 @@ if [ -z "${DAALROOT}" ]; then
     export DAALROOT=${PREFIX}
 fi
 
-if [ `uname` == Darwin ]; then
+if [ $(uname) == Darwin ]; then
     # dead_strip_dylibs does not work with DAAL, which is underlinked by design
     export LDFLAGS="${LDFLAGS//-Wl,-dead_strip_dylibs}"
     export LDFLAGS_LD="${LDFLAGS_LD//-dead_strip_dylibs}"


### PR DESCRIPTION
# Description
This pull request resolves the remaining Bash code quality issues found in codefactor.io, with the intention of making progress towards issue https://github.com/IntelPython/daal4py/issues/316.

Changes proposed in this pull request:
-  Use $(...) notation instead of legacy backticked \`...\` in the following files:
  * `conda-recipe\build.sh`
  * `.circleci/run_and_compare.sh `