### PR TITLE
Improve readability of len(sequence) in conditions

### DIFF
--- a/generator/gen_daal4py.py
+++ b/generator/gen_daal4py.py
@@ -756,7 +756,7 @@ class cython_interface(object):
                     p = '::'.join([pns.replace('algorithms::', ''), splitns(i)[1]])
                     if p in ifaces:
                         ifcs.append(cpp2hl(p))
-            jparams['iface'] = ifcs if len(ifcs) else [None]
+            jparams['iface'] = ifcs if ifcs else [None]
         else:
             jparams = {}
 

--- a/generator/gen_daal4py.py
+++ b/generator/gen_daal4py.py
@@ -49,7 +49,7 @@ def cpp2hl(cls):
 def cleanup_ns(fname, ns):
     """return a sanitized namespace name"""
     # strip of namespace 'interface1'
-    while len(ns) and ns[-1].startswith('interface'):
+    while len(ns) != 0 and ns[-1].startswith('interface'):
         del ns[-1]
     # cleanup duplicates
     while len(ns) >= 2 and ns[-1] == ns[len(ns)-2]:

--- a/generator/wrapper_gen.py
+++ b/generator/wrapper_gen.py
@@ -1297,7 +1297,7 @@ class wrapper_gen(object):
         t = jenv.from_string(algo_iface_template)
         cpp_begin += t.render(**jparams) + '\n'
 
-        if len(jparams):
+        if jparams:
             if 'dist' in cfg:
                 # a wrapper for distributed mode
                 jparams.update(cfg['dist'])


### PR DESCRIPTION
# Description
This pull request resolves the remaining "Use of len(sequence) as condition value in Python" code quality issues found in codefactor.io, with the intention of making progress towards issue #316.

Changes proposed in this pull request:
- Replace `len(jparams)` with `jparams` in condition in `generator/wrapper_gen.py`
- Replace `len(ifcs)` with `ifcs` in condition in `generator/gen_daal4py.py`
- Replace `len(ns)` with `len(ns) != 0` for readability in `generator/gen_daal4py.py`