### PR TITLE
account for no env variable

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,15 +39,8 @@ IS_WIN = False
 IS_MAC = False
 IS_LIN = False
 
-try:
-    daal_root = os.environ['DAALROOT']
-except KeyError :
-    pass
-
-try:
-    dal_root = os.environ['DALROOT']
-except KeyError :
-    pass
+daal_root = os.environ.get('DAALROOT')
+dal_root = os.environ.get('DALROOT')
 if not dal_root:
     dal_root = daal_root
 


### PR DESCRIPTION
The previous implementation would fail if either DAALROOT or DALROOT were not set in the environment because the "try..catch" meant the variable was never defined. If it was never defined, it crashes with a "NameError: name 'dal_root' is not defined" error.

This implementation is both simpler and preserves the original intent, which is to set dal_root=daal_root if DALROOT is not defined in the env.

Note that both implementations leave the possibility that dal_root=None after line 45 (if neither env variable is defined).

# Description
Please include a summary of the change. For large or complex changes please include enough information to introduce your change and explain motivation for it.

Changes proposed in this pull request:
-
-
-

 
