### PR TITLE
Enable DPC++ compiler support on Windows platform

### DIFF
--- a/conda-recipe/bld.bat
+++ b/conda-recipe/bld.bat
@@ -21,4 +21,5 @@ IF DEFINED DPCPPROOT (
 set PATH=%PATH%;%PREFIX%\Library\bin\libfabric
 
 %PYTHON% setup.py build %BUILD_ARGS%
+IF %ERRORLEVEL% neq 0 EXIT /b %ERRORLEVEL%
 %PYTHON% setup.py install --single-version-externally-managed --record record.txt

--- a/conda-recipe/bld.bat
+++ b/conda-recipe/bld.bat
@@ -7,14 +7,18 @@ IF DEFINED DAALROOT (set DALROOT=%DAALROOT%)
 
 IF NOT DEFINED DALROOT (set DALROOT=%PREFIX%) 
 
+set "BUILD_ARGS="
+
 IF DEFINED DPCPPROOT (
     echo "Sourcing DPCPPROOT"
     call "%DPCPPROOT%\env\vars.bat"
     set "CC=dpcpp"
     set "CXX=dpcpp"
     dpcpp --version
+    SET "BUILD_ARGS=--compiler dpcpp"
 )
 
 set PATH=%PATH%;%PREFIX%\Library\bin\libfabric
 
+%PYTHON% setup.py build %BUILD_ARGS%
 %PYTHON% setup.py install --single-version-externally-managed --record record.txt

--- a/dpcppcompiler.py
+++ b/dpcppcompiler.py
@@ -1,3 +1,19 @@
+#===============================================================================
+# Copyright 2021 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#===============================================================================
+
 import distutils.ccompiler
 import sys
 

--- a/dpcppcompiler.py
+++ b/dpcppcompiler.py
@@ -1,0 +1,7 @@
+from distutils.msvccompiler import MSVCCompiler
+
+
+class DPCPPCompiler(MSVCCompiler):
+    def initialize(self):
+        super().initialize()
+        self.cc = "dpcpp.exe"

--- a/dpcppcompiler.py
+++ b/dpcppcompiler.py
@@ -1,7 +1,15 @@
-from distutils.msvccompiler import MSVCCompiler
+import distutils.ccompiler
+import sys
+
+_compiler_module, _compiler_class, _ = distutils.ccompiler.compiler_class["msvc"]
+
+_msvc_compiler_module_name = "distutils." + _compiler_module
+__import__(_msvc_compiler_module_name)
+_msvc_compiler_module = sys.modules[_msvc_compiler_module_name]
+cls = vars(_msvc_compiler_module)[_compiler_class]
 
 
-class DPCPPCompiler(MSVCCompiler):
+class DPCPPCompiler(cls):
     def initialize(self):
         super().initialize()
         self.cc = "dpcpp.exe"

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,9 @@ elif sys.platform in ['win32', 'cygwin']:
         # noinspection PyUnresolvedReferences
         import dpcppcompiler
         sys.modules["distutils.dpcppcompiler"] = sys.modules["dpcppcompiler"]
-        distutils.ccompiler.compiler_class["dpcpp"] = ("dpcppcompiler", "DPCPPCompiler", "Support of DPCPP compiler")
+        distutils.ccompiler.compiler_class["dpcpp"] = (
+            "dpcppcompiler", "DPCPPCompiler", "Support of DPCPP compiler"
+        )
 else:
     assert False, sys.platform + ' not supported'
 
@@ -275,7 +277,11 @@ def getpyexts():
         if os.environ.get('cc', '') == "dpcpp":
             eca.append("/EHsc")
         else:
-            include_dir_plat.append(jp(os.environ.get('ICPP_COMPILER16', ''), 'compiler', 'include'))
+            include_dir_plat.append(
+                jp(os.environ.get('ICPP_COMPILER16', ''),
+                   'compiler',
+                   'include')
+            )
             eca += ['-std=c++11', '-w', '/MD']
     elif not using_intel and IS_WIN:
         eca += ['-wd4267', '-wd4244', '-wd4101', '-wd4996', '/MD']


### PR DESCRIPTION
Enabling of DPC++ compiler on Windows platform by adding a new compiler to distutils module based on existing support of msvc compiler.
