### PR TITLE
DF: fix tests and Sklearn patching

### DIFF
--- a/daal4py/sklearn/ensemble/_forest.py
+++ b/daal4py/sklearn/ensemble/_forest.py
@@ -232,7 +232,8 @@ def _daal_fit_classifier(self, X, y, sample_weight=None):
 
 
 def _daal_predict_classifier(self, X):
-    X = self._validate_X_predict(X)
+    if not daal_check_version((2021, 'P', 200)):
+        X = self._validate_X_predict(X)
     X_fptype = getFPType(X)
     dfc_algorithm = daal4py.decision_forest_classification_prediction(
         nClasses=int(self.n_classes_),
@@ -248,7 +249,8 @@ def _daal_predict_classifier(self, X):
 
 
 def _daal_predict_proba(self, X):
-    X = self._validate_X_predict(X)
+    if not daal_check_version((2021, 'P', 200)):
+        X = self._validate_X_predict(X)
     X_fptype = getFPType(X)
     dfc_algorithm = daal4py.decision_forest_classification_prediction(
         nClasses=int(self.n_classes_),
@@ -442,7 +444,8 @@ def _fit_regressor(self, X, y, sample_weight=None):
 
 
 def _daal_predict_regressor(self, X):
-    X = self._validate_X_predict(X)
+    if not daal_check_version((2021, 'P', 200)):
+        X = self._validate_X_predict(X)
     X_fptype = getFPType(X)
     dfr_alg = daal4py.decision_forest_regression_prediction(fptype=X_fptype)
     dfr_predictionResult = dfr_alg.compute(X, self.daal_model_)

--- a/daal4py/sklearn/ensemble/tests/test_decision_forest.py
+++ b/daal4py/sklearn/ensemble/tests/test_decision_forest.py
@@ -29,13 +29,16 @@ from sklearn.ensemble \
     import RandomForestRegressor as ScikitRandomForestRegressor
 from daal4py.sklearn.ensemble \
     import RandomForestRegressor as DaalRandomForestRegressor
+from daal4py.sklearn._utils import daal_check_version
 
 N_TRIES = 10
-ACCURACY_RATIO = 0.7
-MSE_RATIO = 1.42
-LOG_LOSS_RATIO = 2.28
+ACCURACY_RATIO = 0.85 if daal_check_version((2021, 'P', 200)) else 0.7
+MSE_RATIO = 1.05 if daal_check_version((2021, 'P', 200)) else 1.42
+LOG_LOSS_RATIO = 1.55 if daal_check_version((2021, 'P', 200)) else 2.28
 ROC_AUC_RATIO = 0.978
 IRIS = load_iris()
+
+random.seed(777)
 CLASS_WEIGHTS_IRIS = [
     {0: 0, 1: 0, 2: 0},
     {0: 0, 1: 1, 2: 1},
@@ -133,6 +136,7 @@ def test_classifier_class_weight_iris(weight):
     _test_classifier_class_weight_iris(weight)
 
 
+np.random.seed(777)
 SAMPLE_WEIGHTS_IRIS = [
     (np.full_like(range(150), 0), 'Only 0'),
     (np.full_like(range(150), 1), 'Only 1'),

--- a/deselected_tests.yaml
+++ b/deselected_tests.yaml
@@ -92,13 +92,6 @@ deselected_tests:
   # https://github.com/IntelPython/daal4py/issues/277
   - cluster/tests/test_k_means.py::test_kmeans_elkan_results
 
-  # Insufficient prediction accuracy for decision forest regression
-  # Case test_boston will be renamed since 0.24 version on test_regression
-  # This problem will be fixed
-  - ensemble/tests/test_forest.py::test_memory_layout
-  - ensemble/tests/test_forest.py::test_regression
-  - ensemble/tests/test_forest.py::test_boston
-
   # Different interpretation of trees compared to scikit-learn
   # Looks like we need to align tree traversal. This problem will be fixed
   - ensemble/tests/test_forest.py::test_min_samples_leaf
@@ -119,18 +112,20 @@ deselected_tests:
   # Comparison of tree forest will be failed
   - ensemble/tests/test_forest.py::test_warm_start_clear
   - ensemble/tests/test_forest.py::test_class_weights
-  - ensemble/tests/test_stacking.py::test_stacking_cv_influence
   - inspection/tests/test_permutation_importance.py::test_robustness_to_high_cardinality_noisy_feature
   - tests/test_common.py::test_estimators
   - tests/test_multioutput.py::test_multi_output_classification
-  - utils/tests/test_estimator_checks.py::test_check_estimator_clones
-
-  # sometimes failed due to non deterministic results in RF
-  # will fixed to next release
-  - tests/test_multioutput.py::test_classifier_chain_tuple_order
 
   # Different behavior when 1 class enters the input
   - feature_selection/tests/test_rfe.py::test_rfe_cv_groups
+
+  # The bugs are fixed in 2021.2 release
+  - ensemble/tests/test_forest.py::test_memory_layout
+  - ensemble/tests/test_forest.py::test_regression # pass for defaultDence method only
+  - ensemble/tests/test_forest.py::test_boston
+  - ensemble/tests/test_stacking.py::test_stacking_cv_influence
+  - utils/tests/test_estimator_checks.py::test_check_estimator_clones
+  - tests/test_multioutput.py::test_classifier_chain_tuple_order
 
   # The bugs are fixed. Remove these tests from deselected after the gold release
   - ensemble/tests/test_bagging.py::test_classification


### PR DESCRIPTION
Changes:
- Fix our internal tests of Random Forest + tighten convergence parameters;
- Fix patching;
- 6 Sklearn tests from deselected list are passed in oneDAL v2021.2

[Related PR in oneDAL](https://github.com/oneapi-src/oneDAL/pull/1440)